### PR TITLE
"Parallelize" file fetching from git history

### DIFF
--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
 import collections
+import concurrent.futures
 import datetime
+from functools import partial
 import json
 import pprint
 import subprocess
@@ -25,11 +27,14 @@ def git_show(ref, name):
 
 
 def fetch_all_results_jsons():
-    jsons = []
-    for rev in git_commits_for("results.json"):
-        jsons.append(json.loads(git_show(rev, 'results.json')))
-    jsons.sort(key=lambda j: j['meta']['timestamp']) # Really make sure we’re in order
-    return jsons
+    commits = git_commits_for("results.json")
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        blobs = executor.map(partial(git_show, name="results.json"), commits)
+
+    jsons = (json.loads(blob) for blob in blobs)
+
+    return sorted(jsons, key=lambda j: j['meta']['timestamp']) # Really make sure we’re in order
 
 # List of results.json dicts, in chronological order
 jsons = fetch_all_results_jsons()


### PR DESCRIPTION
Experimentally this reduces ~40% of the wall clock time, but might be mostly disk-latency related improvements for my setup:

Example:
```
$ time ./print-battleground-state-changes >/dev/null # multi-thread

real    0m16.489s
user    0m24.063s
sys     0m6.008s

$ time ./print-battleground-state-changes >/dev/null # single-thread

real    0m26.244s
user    0m20.721s
sys     0m5.676s
```