### PR TITLE
Use the right time for the last batch

### DIFF
--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -4,6 +4,7 @@ import collections
 import concurrent.futures
 import datetime
 from functools import partial
+import itertools
 import json
 import subprocess
 from tabulate import tabulate
@@ -248,7 +249,7 @@ with open("battleground-state-changes.html.tmpl", "r", encoding='utf8') as f:
 
 html_chunks = []
 
-batch_time = datetime.datetime.strptime(jsons[0]['meta']['timestamp'], '%Y-%m-%dT%H:%M:%S.%fZ')
+batch_time = max(itertools.chain.from_iterable(summarized.values()), key=lambda s: s.timestamp).timestamp
 print(tabulate([
     ["Last updated:", scrape_time.strftime("%Y-%m-%d %H:%M UTC")],
     ["Latest batch received:", batch_time.strftime("%Y-%m-%d %H:%M UTC")],


### PR DESCRIPTION
The data returned by `fetch_all_results_jsons()` is ascending. So just grabbing the first one isn't right. :(

This:
```
----------------------  --------------------
Last updated:           2020-11-05 08:54 UTC
Latest batch received:  2020-11-05 07:45 UTC
----------------------  --------------------
```

Instead of this:
```
----------------------  --------------------
Last updated:           2020-11-05 08:52 UTC
Latest batch received:  2020-11-04 13:28 UTC
----------------------  --------------------
```