### PR TITLE
Switch from normal json to pysimdjson

### DIFF
--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -5,7 +5,7 @@ import concurrent.futures
 import datetime
 from functools import partial
 import itertools
-import json
+import simdjson
 import subprocess
 from tabulate import tabulate
 
@@ -33,9 +33,10 @@ def fetch_all_results_jsons():
     with concurrent.futures.ThreadPoolExecutor() as executor:
         blobs = executor.map(partial(git_show, name="results.json"), commits)
 
-    jsons = (json.loads(blob) for blob in blobs)
+    parsers = [simdjson.Parser() for blob in commits] # These can't be reused apparently
+    jsons = (parser.parse(blob) for parser, blob in zip(parsers, blobs))
 
-    return sorted(jsons, key=lambda j: j['meta']['timestamp']) # Really make sure we’re in order
+    return sorted(jsons, key=lambda j: j['meta']['timestamp']), parsers # Really make sure we’re in order
 
 # Information that is shared across loop iterations
 IterationInfo = collections.namedtuple(
@@ -168,7 +169,7 @@ def html_summary(summary: IterationSummary):
 scrape_time = datetime.datetime.utcnow()
 
 # List of results.json dicts, in chronological order
-jsons = fetch_all_results_jsons()
+jsons, _pysimdjson_lifetime_hacks = fetch_all_results_jsons()
 
 # Where we’ll aggregate the data from the JSON files
 summarized = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 tabulate==0.8.7
+pysimdjson==3.1.0


### PR DESCRIPTION
We're parsing around 2.5GB of json data so parsing the json is starting to be nearly all execution time

```
 $ time ./print-battleground-state-changes >/dev/null #simdjson

real    0m13.027s
user    0m28.958s
sys     0m32.161s
 $ time ./print-battleground-state-changes >/dev/null #json

real    0m54.327s
user    1m12.686s
sys     0m31.288s
```