### PR TITLE
allow to dynamically specify the number of rows

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -33,9 +33,7 @@
     <script>
         var urlParams = new URLSearchParams(window.location.search);
         var rows = parseInt(urlParams.get("rows"))
-        console.log(rows)
         if (rows) {
-            console.log("hello")
             var style=document.createElement('style');
             style.type='text/css';
             style.appendChild(document.createTextNode('tbody tr:nth-child(n+'+ (rows + 1) + ') { display:none;}'));

--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -29,8 +29,19 @@
     .Trump{
         background-color: #ED98A9;
     }
-}
     </style>
+    <script>
+        var urlParams = new URLSearchParams(window.location.search);
+        var rows = parseInt(urlParams.get("rows"))
+        console.log(rows)
+        if (rows) {
+            console.log("hello")
+            var style=document.createElement('style');
+            style.type='text/css';
+            style.appendChild(document.createTextNode('tbody tr:nth-child(n+'+ (rows + 1) + ') { display:none;}'));
+            document.getElementsByTagName('head')[0].appendChild(style);
+        }
+    </script>
     <title>Election 2020 | Last scrape: {% SCRAPE %}</title>
 </head>
 


### PR DESCRIPTION
This would allow to fix this issue: https://github.com/alex/nyt-2020-election-scraper/issues/40
But this requires to put the `rows` query parameter manually, not sure what's the best way to do this in the UI, I'd rather not mess with it