### PR TITLE
Switch from parallel subprocesses to an actual git client

### DIFF
--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 
 import collections
-import concurrent.futures
 import datetime
-from functools import partial
+import git
 import itertools
 import simdjson
 import subprocess
@@ -22,16 +21,16 @@ STATE_INDEXES = [AK_INDEX, AZ_INDEX, GA_INDEX, NC_INDEX, NV_INDEX, PA_INDEX]
 def git_commits_for(path):
     return subprocess.check_output(['git', 'log', "--format=%H", path]).strip().decode().splitlines()
 
+def git_show(ref, name, repo_client):
+    commit_tree = repo_client.commit(ref).tree
 
-def git_show(ref, name):
-    return subprocess.check_output(['git', 'show', ref + ':' + name])
-
+    return commit_tree[name].data_stream.read()
 
 def fetch_all_results_jsons():
     commits = git_commits_for("results.json")
 
-    with concurrent.futures.ThreadPoolExecutor() as executor:
-        blobs = executor.map(partial(git_show, name="results.json"), commits)
+    repo = git.Repo('.', odbt=git.db.GitCmdObjectDB)
+    blobs = (git_show(ref, "results.json", repo) for ref in commits)
 
     parsers = [simdjson.Parser() for blob in commits] # These can't be reused apparently
     jsons = (parser.parse(blob) for parser, blob in zip(parsers, blobs))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 tabulate==0.8.7
 pysimdjson==3.1.0
+GitPython==3.1.11


### PR DESCRIPTION
Switch from running lots of `git show COMMIT:PATH` commands to using `GitPython`'s `git cat-file --batch` client.

This is about a 1/3rd speed up on wall clock time and a significant improvement on CPU efficiency

Perf improvements:
```
 $ time ./print-battleground-state-changes >/dev/null # subprocessing

real    0m14.877s
user    0m31.301s
sys     0m38.459s

 $ time ./print-battleground-state-changes >/dev/null # subprocessing

real    0m14.639s
user    0m30.916s
sys     0m37.852s

 $ time ./print-battleground-state-changes >/dev/null # subprocessing

real    0m15.581s
user    0m32.333s
sys     0m39.558s

 $ time ./print-battleground-state-changes >/dev/null # git-cat-file

real    0m10.194s
user    0m6.301s
sys     0m4.620s

 $ time ./print-battleground-state-changes >/dev/null # git-cat-file

real    0m10.067s
user    0m5.858s
sys     0m4.975s

 $ time ./print-battleground-state-changes >/dev/null # git-cat-file

real    0m10.195s
user    0m6.142s
sys     0m4.692s
```