### PR TITLE
Add sticky table headers so it's easier to see which state's data you're looking at 

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -17,7 +17,17 @@
     .table td, .table th {
         padding: .25rem .5rem;
     }
+    
+    .table th.text-center {
+        position: sticky;
+        top: -1px;
+    }
 
+     .table th.has-tip {
+        position: sticky;
+        top: calc(.25rem + 1.5rem + 2px);
+    }
+    
     .has-tip:after{
         content: "ℹ";
         margin-left: 5px;
@@ -65,11 +75,6 @@
         This website is <a href="https://github.com/alex/nyt-2020-election-scraper">open source</a> and was written by <a href="https://github.com/alex/nyt-2020-election-scraper/graphs/contributors">these people</a>.
     </p>
 
-    <p class="text-right">
-      <button type='button' id='shrink_button' class='btn btn-secondary'>Shrink Tables</button>
-    </p>
-
-
     {% TABLES %}
 
     <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"
@@ -98,35 +103,5 @@
         $(".timestamp").map(function (idx, tselem) {
             tselem.innerHTML = "<abbr title='" + tselem.innerHTML + "'>" + dayjs.utc(tselem.innerHTML.replace(" UTC", ""), 'YYYY-MM-DD HH:MM:SS').fromNow() + "</abbr>"
         })
-
-        const $shrinkButton = $('#shrink_button');
-
-        const shrinkTables = () => {
-            $shrinkButton.html('Expand Tables');
-            $('.table').each(function() { $(this).find('tbody tr:gt(2)').hide(); });
-            localStorage.setItem(shrunkLocalStorageKey, 'true');
-        };
-
-        const expandTables = () => {
-            $shrinkButton.html('Shrink Tables');
-            $('.table').each(function() { $(this).find('tbody tr').show(); });
-            localStorage.removeItem(shrunkLocalStorageKey);
-        };
-
-        const isShrunk = () => localStorage.getItem(shrunkLocalStorageKey) === 'true';
-
-        const shrunkLocalStorageKey = 'shrunk';
-
-        $shrinkButton.on('click', function() {
-            if (isShrunk()) {
-                expandTables();
-            } else {
-                shrinkTables();
-            }
-        });
-
-        if (localStorage.getItem(shrunkLocalStorageKey)) {
-            shrinkTables();
-        }
     </script>
 </body>


### PR DESCRIPTION
Added some sticky headers so that it's easy to tell what state you're looking at as you scroll down.
Size is calculated based on table padding, font-size and linespacing, and the border-width.