### PR TITLE
Adding a second GHA to help with reviews

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,31 @@
+name: PR
+
+on:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out this repo
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+    - name: Install Python requirements
+      run: |-
+        python -m pip install -U pip
+        pip install -r requirements.txt
+    - name: Generate battleground-state-changes.txt/html
+      run: |-
+        ./print-battleground-state-changes > tmp
+        mv tmp battleground-state-changes.txt
+    - name: Upload test artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: battleground-state-changes
+        path: |
+          battleground-state-changes.*


### PR DESCRIPTION
This runs the build & uploads the outputs to GHA so we don't have to ask for screenshots / output checks.