### PR TITLE
Remove 0 change when shrinking the table

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -158,13 +158,15 @@
             button.html('Expand Tables');
             $('.table').each(function(){
                 var countOfNonHiddenBlock = 0;
+                var lastCount = -1;
                 $(this).find('tbody tr').each(function() {
                     var value = parseInt(($(this).find('td:nth(4)').text()));
-                    if (countOfNonHiddenBlock >= 3 || value === 0) {
+                    if (countOfNonHiddenBlock >= 3 || (value === 0 && lastCount === 0)) {
                         $(this).hide();
                     } else {
                         countOfNonHiddenBlock++;
                     }
+                    lastCount = value;
                 });
             });
         }, button => {

--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -157,9 +157,9 @@
         feature(shrinkTablesFeature, '#shrink_button', button => {
             button.html('Expand Tables');
             $('.table').each(function(){
-                var countOfNonHiddenBlock = 0
+                var countOfNonHiddenBlock = 0;
                 $(this).find('tbody tr').each(function() {
-                    var value = parseInt(($(this).find('td:nth(4)').text()))
+                    var value = parseInt(($(this).find('td:nth(4)').text()));
                     if (countOfNonHiddenBlock >= 3 || value === 0) {
                         $(this).hide();
                     } else {

--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -156,7 +156,17 @@
         const shrinkTablesFeature = 'shrunk';
         feature(shrinkTablesFeature, '#shrink_button', button => {
             button.html('Expand Tables');
-            $('.table').each(function() { $(this).find('tbody tr:gt(2)').hide(); });
+            $('.table').each(function(){
+                var countOfNonHiddenBlock = 0
+                $(this).find('tbody tr').each(function() {
+                    var value = parseInt(($(this).find('td:nth(4)').text()))
+                    if (countOfNonHiddenBlock >= 3 || value === 0) {
+                        $(this).hide();
+                    } else {
+                        countOfNonHiddenBlock++;
+                    }
+                });
+            });
         }, button => {
             button.html('Shrink Tables');
             $('.table').each(function() { $(this).find('tbody tr').show(); });


### PR DESCRIPTION
If we want to do so, this will remove the lines where the change is == 0 when the table is shrunk

Relates to https://github.com/alex/nyt-2020-election-scraper/issues/91