### PR TITLE
fix: clean up information emoji

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -36,7 +36,7 @@
     }
 
     .has-tip:after{
-        content: "ℹ";
+        content: "\2139\fe0f";
         margin-left: 5px;
     }
 

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -177,16 +177,10 @@ def html_write_state_head(state: str, summary: IterationSummary):
             <th class="has-tip" data-toggle="tooltip" title="How many votes separate the two candidates?">Vote Differential</th>
             <th class="has-tip" data-toggle="tooltip" title="Approximately how many votes are remaining to be counted? These values might be off! Consult state websites and officials for the most accurate and up-to-date figures.">Votes Remaining (est.)</th>
             <th class="has-tip" data-toggle="tooltip" title="How many votes were reported in this block?">Change</th>
-            <th class="has-tip" data-toggle="tooltip" title="How did the votes in this block break down, per candidate. Based on the number of reported votes and the change in differential.">
-                Block Breakdown
-            </th>
-            <th class="has-tip" data-toggle="tooltip" title="How has the trailing candidate's share of recent blocks trended? Computed using a moving average of previous 30k or more votes (or as many as available).">
-                Block Trend
-            </th>
+            <th class="has-tip" data-toggle="tooltip" title="How did the votes in this block break down, per candidate. Based on the number of reported votes and the change in differential.">Block Breakdown</th>
+            <th class="has-tip" data-toggle="tooltip" title="How has the trailing candidate's share of recent blocks trended? Computed using a moving average of previous 30k or more votes (or as many as available).">Block Trend</th>
             <th class="has-tip" data-toggle="tooltip" title="How many precincts have reported?">Precincts Reporting</th>
-            <th class="has-tip" data-toggle="tooltip" title="What percentage of the remaining votes does the trailing candidate need to flip the lead. 'Flip' happens at 50%, not at 0%.">\
-                Hurdle
-            </th>
+            <th class="has-tip" data-toggle="tooltip" title="What percentage of the remaining votes does the trailing candidate need to flip the lead. 'Flip' happens at 50%, not at 0%.">Hurdle</th>
         </tr>
         </thead>
     '''


### PR DESCRIPTION
Removes extra space before them on three columns (doesn't lengthen
the longest line of code, either) and forces the emoji to be emoji,
rather than the "i" icon which is the default in some configurations.

There's still an extra space at the end of the table headers, as I'm not sure how best to resolve that. In FF for me, the second line isn't hoverable _anyway_, despite it being commented on by the tooltip, so I'm staying out of that for now.