### PR TITLE
Fixed sticky table headers

### DIFF
--- a/battleground-state-changes.html
+++ b/battleground-state-changes.html
@@ -30,7 +30,7 @@
     .table th.text-left {
         font-weight: normal;
         position: sticky;
-        top: -1px;
+        top: -1px !important;
     }
 
     .table th span.statename {
@@ -40,7 +40,7 @@
 
      .table th.has-tip {
         position: sticky;
-        top: calc(.25rem + 1.5rem + 2px);
+        top: calc(3.6rem + 3px);
     }
 
     .has-tip:after{


### PR DESCRIPTION
Slightly changed the CSS on the table header to fix the issue where the top line of the table header does not properly stick to the top of the window