### PR TITLE
fix: better sticky headers

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -27,8 +27,6 @@
 
     .table th.text-left {
         font-weight: normal;
-        position: sticky;
-        top: -1px;
     }
 
     .table th span.statename {
@@ -36,9 +34,16 @@
         font-size: 14pt;
     }
 
-     .table th.has-tip {
+    thead tr:nth-child(1) th {
+        position: sticky;
+        top: -1px;
+    }
+
+    thead tr:nth-child(2) th {
         position: sticky;
         top: calc(.25rem + 1.5rem + 2px);
+        border-right: none;
+        border-left: none;
     }
 
     .has-tip:after{


### PR DESCRIPTION
Due to Chrome bug 702927 we can't sticky the thead, so instead we reuse
the code that existed but properly grab the right set of headers.

In Chrome (again...) this means the header borders are transparent (because
we're stickying the cells, not their borders, I guess), so I've also removed
the left/right borders in the thead cells to avoid a visual artifact. This
seems fine, but can be reverted if appropriate.