### PR TITLE
Add PR check to fail on static file change

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,6 +19,18 @@ jobs:
       run: |-
         python -m pip install -U pip
         pip install -r requirements.txt
+
+    - id: files
+      uses: jitterbit/get-changed-files@v1
+    - name: Check for changed static files
+      run: |
+        for changed_file in ${{ steps.files.outputs.modified }}; do
+          if [[ "${changed_file}" =~ ^(battleground-state-changes.csv|battleground-state-changes.html|battleground-state-changes.txt)$ ]]; then
+            echo "Modifications to static files are not allowed."
+            exit 1
+          fi
+        done
+
     - name: Generate battleground-state-changes.txt/html
       run: |-
         ./print-battleground-state-changes > tmp

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Check for changed static files
       run: |
         for changed_file in ${{ steps.files.outputs.modified }}; do
-          if [[ "${changed_file}" =~ ^(battleground-state-changes.csv|battleground-state-changes.html|battleground-state-changes.txt)$ ]]; then
+          if [[ "${changed_file}" =~ ^(battleground-state-changes.csv|battleground-state-changes.html|battleground-state-changes.txt|notification-updates.json)$ ]]; then
             echo "Modifications to static files are not allowed."
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ Outputted files:
 - <https://alex.github.io/nyt-2020-election-scraper/battleground-state-changes.csv>
 
 Inspired by Simon Willison: https://simonwillison.net/2020/Oct/9/git-scraping/
+
+## Development
+
+Please do not modify any of the static files (html, csv, or txt). These files are dynamically generated.


### PR DESCRIPTION
Adds a PR check using [jitterbit/get-changed-files@v1](https://github.com/marketplace/actions/get-all-changed-files). Don't have a great way to test this unfortunately. I did test the `run` part of it.