### PR TITLE
Just change td to th for state headers

### DIFF
--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -167,13 +167,13 @@ def html_write_state_head(state: str, state_slug: str, summary: IterationSummary
     return f'''
         <thead class="thead-light">
         <tr>
-            <th class="text-left has-tip" colspan="9">
+            <td class="text-left has-tip" colspan="9">
                 <span data-toggle="tooltip" title="Number of electoral votes contributed by this state and total votes by each candidate.">
                     <img src="flags/{state_slug}.svg" width="50px" /> <span class="statename">{state}</span>
                 </span>
                 <br>
                 Total Votes: {summary.leading_candidate_name} leads with {summary.leading_candidate_votes:,} votes, {summary.trailing_candidate_name} trails with {summary.trailing_candidate_votes:,} votes.
-            </th>
+            </td>
         </tr>
         <tr>
             <th class="has-tip" data-toggle="tooltip" title="When did this block of votes get reported?">Timestamp</th>


### PR DESCRIPTION
To address #127 

Before:

![image](https://user-images.githubusercontent.com/7196177/98325582-24b42d80-1fbd-11eb-9443-f7a4a572b3f6.png)

After 

![image](https://user-images.githubusercontent.com/7196177/98325617-3a295780-1fbd-11eb-9595-5e0aab7b6910.png)

Slightly less uniform in top-matter format for each table, but fits the request.