### PR TITLE
Add continue-on-error true to ignore head/base commit issue

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,6 +22,7 @@ jobs:
 
     - id: files
       uses: jitterbit/get-changed-files@v1
+      continue-on-error: true
     - name: Check for changed static files
       run: |
         for changed_file in ${{ steps.files.outputs.modified }}; do


### PR DESCRIPTION
###### Motivation

https://github.com/jitterbit/get-changed-files/blob/master/src/main.ts#L49-L53 checks that head and base match which isn't going to work well with how PR's get opened for this repository. The action still works and correctly displays the modified files so we can add `continue-on-error: true` to skip this issue.

See also https://github.com/jitterbit/get-changed-files/issues/11

Examples:

* https://github.com/alex/nyt-2020-election-scraper/pull/146/checks?check_run_id=1361936132#step:5:10
* https://github.com/alex/nyt-2020-election-scraper/pull/147/checks?check_run_id=1361939259#step:5:10

###### Changes

Use `continue-on-error: true` for the `get-changed-files` PR step.

- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv` and `*.json` files.
