### PR TITLE
Move state summary to a table caption

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -22,7 +22,19 @@
     body {
         margin: 1rem;
     }
+
+    caption {
+        caption-side: top;
+        color: #333
+    }
     
+    .box {
+        display: inline-block;
+        height: 20px;
+        width: 20px;
+        vertical-align: middle;
+    }
+
     .table td, .table th {
         padding: .25rem .5rem;
     }

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -186,16 +186,18 @@ def string_summary(summary):
 
 def html_write_state_head(state: str, state_slug: str, summary: IterationSummary):
     return f'''
+        <caption>
+            <h2 class="has-tip" data-toggle="tooltip" title="Number of electoral votes contributed by this state and total votes by each candidate.">
+                <img src="flags/{state_slug}.svg" width="50px" />
+                <span class="statename">{state}</span>
+            </h2>
+            <span>
+                Total Votes:
+                <div class="box {summary.leading_candidate_name}"></div> {summary.leading_candidate_name} leads with {summary.leading_candidate_votes:,} votes,
+                <div class="box {summary.trailing_candidate_name}"></div> {summary.trailing_candidate_name} trails with {summary.trailing_candidate_votes:,} votes.
+            </span>
+        </caption>
         <thead class="thead-light">
-        <tr>
-            <td class="text-left flag-bg" style="background-image: url('flags/{state_slug}.svg')" colspan="9">
-                <span class="has-tip" data-toggle="tooltip" title="Number of electoral votes contributed by this state and total votes by each candidate.">
-                    <span class="statename">{state}</span>
-                </span>
-                <br>
-                Total Votes: {summary.leading_candidate_name} leads with {summary.leading_candidate_votes:,} votes, {summary.trailing_candidate_name} trails with {summary.trailing_candidate_votes:,} votes.
-            </td>
-        </tr>
         <tr>
             <th class="has-tip" data-toggle="tooltip" title="When did this block of votes get reported?">Timestamp</th>
             <th class="has-tip" data-toggle="tooltip" title="Which candidate currently leads this state?">In The Lead</th>


### PR DESCRIPTION
Relocate the overall state summary information to a `<caption>` instead of a `<th>`, which causes accessibility issues per #127.

Resolves #127

Before:
![127-before-v2](https://user-images.githubusercontent.com/22353962/98327026-9e99e600-1fc0-11eb-8757-6f7a4c49cb45.png)

After:
![127-after](https://user-images.githubusercontent.com/22353962/98327079-bcffe180-1fc0-11eb-8b5d-dc038b916da9.png)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation

###### Changes

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [X] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [X] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv` and `*.json` files.
