### PR TITLE
work around layout flash by shrinking html timestamps

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -23,6 +23,14 @@
         margin: 1rem;
     }
     
+    /* work around layout flash by making pre-localized timestamps much smaller */
+    .timestamp {
+        font-size: 8pt;
+    }
+    .pretty-timestamp {
+        font-size: 12pt;
+    }
+
     .table td, .table th {
         padding: .25rem .5rem;
     }


### PR DESCRIPTION
This fixes large layout flash for me on load / refresh as the timestamps are edited by JS which triggers a re-layout.

No screenshot applicable - this does not change the rendered UI for me. If you want to repro, Chrome flashes on every refresh for me before this change