### PR TITLE
fix: use a td instead of a th for state names, sticky header

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -86,7 +86,7 @@
             color: #dedad6;
             background-color: #202020;
         }
-        .table .thead-light th, .table .thead-light th {
+        .table .thead-light th, .table .thead-light td {
             background-color: #495057;
             color: #e9ecef;
         }

--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -27,25 +27,35 @@
         padding: .25rem .5rem;
     }
 
-    .table th.text-left {
+    thead td {
+      background-color: #e9ecef;
+      line-height: 1.2rem;
+    }
+
+    thead .text-left {
         font-weight: normal;
     }
 
-    .table th span.statename {
+    thead span.statename {
         font-weight: bold;
-        font-size: 14pt;
+        /* If changing these, update "thead tr:nth-child(2) th" too */
+        font-size: 1.2rem;
+        line-height: 1.2rem;
     }
 
-    thead tr:nth-child(1) th {
+    thead tr:nth-child(1) td {
         position: sticky;
         top: -1px;
+        border-bottom: none;
     }
 
     thead tr:nth-child(2) th {
         position: sticky;
-        top: calc(.25rem + 1.5rem + 2px);
+        /* Padding, first line, second line, padding */
+        top: calc(.25rem + 1.2rem + 1.2rem + .25rem);
         border-right: none;
         border-left: none;
+        border-top: none;
     }
 
     .has-tip:after{
@@ -56,7 +66,7 @@
     .flag-bg {
         background-position: fixed;
         background-repeat: no-repeat;
-        background-size: 100px;
+        background-size: auto 100%;
         background-position: 100%;
     }
 
@@ -76,7 +86,7 @@
             color: #dedad6;
             background-color: #202020;
         }
-        .table .thead-light th {
+        .table .thead-light th, .table .thead-light th {
             background-color: #495057;
             color: #e9ecef;
         }

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -167,13 +167,13 @@ def html_write_state_head(state: str, state_slug: str, summary: IterationSummary
     return f'''
         <thead class="thead-light">
         <tr>
-            <th class="text-left has-tip flag-bg" style="background-image: url('flags/{state_slug}.svg')" colspan="9">
+            <td class="text-left has-tip flag-bg" style="background-image: url('flags/{state_slug}.svg')" colspan="9">
                 <span data-toggle="tooltip" title="Number of electoral votes contributed by this state and total votes by each candidate.">
                     <span class="statename">{state}</span>
                 </span>
                 <br>
                 Total Votes: {summary.leading_candidate_name} leads with {summary.leading_candidate_votes:,} votes, {summary.trailing_candidate_name} trails with {summary.trailing_candidate_votes:,} votes.
-            </th>
+            </td>
         </tr>
         <tr>
             <th class="has-tip" data-toggle="tooltip" title="When did this block of votes get reported?">Timestamp</th>


### PR DESCRIPTION
###### Motivation

We want to make the table headers a `td` instead of `th` for screen reader users, and fix the sticky headers being a little overlappy (and handle flags in them).

###### Changes

Closes #127 and fixes up the sticky headers to be cleaner: they now use an expected rem height that matches the height of the first row, and auto-set flag heights to fill that as well.

Appears to work in Chrome and FF, with a minor visual artifact in FF when scrolling up into a new table for a couple rows (with a single-pixel gap between the first two rows). Unclear what can be done about that, if anything, so I'll leave it be.

Looks like this when scrolling:
![Screenshot from 2020-11-05 22-40-41](https://user-images.githubusercontent.com/29508/98326926-013ab400-1fb8-11eb-8373-98ea0850d47d.png)

The Firefox artifact goes away when hovering, which makes a screenshot difficult, but I can get one if necessary.

- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv` and `*.json` files.
