### PR TITLE
modified sma calc to compute a fraction of last block to get to 30k v…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+## Contributing
+
+Welcome! :wave:
+
+We're happy to consider new contributions to the project. That being said, a core aim of this project is comparative simplicity in the user interface, and we need to balance new features against the cost of added complexity. We feel we're approaching a logical point of feature completion, and at this point are focusing more on refinements that improve performance and reduce bugginess.
+
+This is to say that we ask two things, before you open a pull request:
+
+1. Please open an issue to discuss your proposal with the developers.
+
+2. Please follow the [pull request template](https://github.com/alex/nyt-2020-election-scraper/blob/master/.github/pull_request_template.md).

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Inspired by Simon Willison: https://simonwillison.net/2020/Oct/9/git-scraping/
 
 ## Development
 
-Contributions are welcome, but please make sure you read and fill out the [the pull request template](.github/pull_request_template.md) when submitting your changes.
+Contributions are welcome, but please make sure you read and fill out the [the pull request template](.github/pull_request_template.md) when submitting your changes. We would also appreciate it if you could read the short [contributing guide](https://github.com/alex/nyt-2020-election-scraper/blob/master/CONTRIBUTING.md).
 
 Please do not modify any of the static files (html, csv, or txt). These files are dynamically generated.

--- a/battleground-state-changes.html
+++ b/battleground-state-changes.html
@@ -104,7 +104,7 @@
         This website is <a href="https://github.com/alex/nyt-2020-election-scraper">open source</a> and was written by <a href="https://github.com/alex/nyt-2020-election-scraper/graphs/contributors">these people</a>.
     </p>
 
-    <p class="float-left" id="timestamps">Last scrape: <span class="timestamp">2020-11-06 04:58:47 UTC</span> | Last batch: <span class="timestamp">2020-11-06 04:51:40 UTC</span></p>
+    <p class="float-left" id="timestamps">Last scrape: <span class="timestamp">2020-11-06 04:59:49 UTC</span> | Last batch: <span class="timestamp">2020-11-06 04:51:40 UTC</span></p>
 
     <p class="float-right">
       <button type='button' id='live_update_button' class='btn btn-secondary'>Enable Live Updates</button>

--- a/battleground-state-changes.html
+++ b/battleground-state-changes.html
@@ -104,7 +104,7 @@
         This website is <a href="https://github.com/alex/nyt-2020-election-scraper">open source</a> and was written by <a href="https://github.com/alex/nyt-2020-election-scraper/graphs/contributors">these people</a>.
     </p>
 
-    <p class="float-left" id="timestamps">Last scrape: <span class="timestamp">2020-11-06 04:54:01 UTC</span> | Last batch: <span class="timestamp">2020-11-06 04:51:40 UTC</span></p>
+    <p class="float-left" id="timestamps">Last scrape: <span class="timestamp">2020-11-06 04:58:47 UTC</span> | Last batch: <span class="timestamp">2020-11-06 04:51:40 UTC</span></p>
 
     <p class="float-right">
       <button type='button' id='live_update_button' class='btn btn-secondary'>Enable Live Updates</button>
@@ -5838,7 +5838,7 @@
                 return;
             }
 
-            if (Notification.permission !== "denied") {
+            if (Notification.permission !== "granted") {
                 Notification.requestPermission();
             }
         }, button => {

--- a/battleground-state-changes.html
+++ b/battleground-state-changes.html
@@ -104,7 +104,7 @@
         This website is <a href="https://github.com/alex/nyt-2020-election-scraper">open source</a> and was written by <a href="https://github.com/alex/nyt-2020-election-scraper/graphs/contributors">these people</a>.
     </p>
 
-    <p class="float-left" id="timestamps">Last scrape: <span class="timestamp">2020-11-06 04:52:19 UTC</span> | Last batch: <span class="timestamp">2020-11-06 04:51:40 UTC</span></p>
+    <p class="float-left" id="timestamps">Last scrape: <span class="timestamp">2020-11-06 04:54:01 UTC</span> | Last batch: <span class="timestamp">2020-11-06 04:51:40 UTC</span></p>
 
     <p class="float-right">
       <button type='button' id='live_update_button' class='btn btn-secondary'>Enable Live Updates</button>

--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -215,7 +215,7 @@
                 return;
             }
 
-            if (Notification.permission !== "denied") {
+            if (Notification.permission !== "granted") {
                 Notification.requestPermission();
             }
         }, button => {

--- a/battleground-state-changes.txt
+++ b/battleground-state-changes.txt
@@ -1,5 +1,5 @@
 ----------------------  --------------------------------------------------------------------------------
-Last updated:           2020-11-06 04:58 UTC
+Last updated:           2020-11-06 04:59 UTC
 Latest batch received:  2020-11-06 04:51 UTC
 Prettier web version:   https://alex.github.io/nyt-2020-election-scraper/battleground-state-changes.html
 ----------------------  --------------------------------------------------------------------------------
@@ -175,7 +175,7 @@ Nevada (EV: 6) Total Votes: (Biden: 604,251, Trump: 592,813)
 Pennsylvania (EV: 20) Total Votes: (Trump: 3,283,032, Biden: 3,258,548)
 ----------------  ---  ------------------------------  ---------------------------  --------------------------------------------  --------------------  ----------------------------  -------------------------
 2020-11-06 04:51  ***  Trump leading by 23,953 votes   Remaining (est.): 286,775    Change:   1,254 (Trump 28.8% / 71.2% Biden)   Precincts: 8372/9128  Biden needs 54.18% [-0.074%]  Biden recent trend 77.88%
-2020-11-06 04:29  ***  Trump leading by 24,484 votes   Remaining (est.): 288,029    Change:   3,865 (Trump 26.3% / 73.7% Biden)   Precincts: 8371/9128  Biden needs 54.25% [-0.258%]  Biden recent trend 78.08%
+2020-11-06 04:29  ---  Trump leading by 24,484 votes   Remaining (est.): 288,029    Change:   3,865 (Trump 26.3% / 73.7% Biden)   Precincts: 8371/9128  Biden needs 54.25% [-0.258%]  Biden recent trend 78.08%
 2020-11-06 03:45  ---  Trump leading by 26,319 votes   Remaining (est.): 291,894    Change:  13,909 (Trump 13.1% / 86.9% Biden)   Precincts: 8366/9128  Biden needs 54.51% [-1.471%]  Biden recent trend 78.50%
 2020-11-06 03:33  ---  Trump leading by 36,572 votes   Remaining (est.): 305,803    Change:   8,046 (Trump 20.6% / 79.4% Biden)   Precincts: 8338/9128  Biden needs 55.98% [-0.601%]  Biden recent trend 72.42%
 2020-11-06 03:16  ---  Trump leading by 41,305 votes   Remaining (est.): 313,849    Change:   2,431 (Trump 32.8% / 67.2% Biden)   Precincts: 8328/9128  Biden needs 56.58% [-0.082%]  Biden recent trend 71.73%

--- a/battleground-state-changes.txt
+++ b/battleground-state-changes.txt
@@ -1,5 +1,5 @@
 ----------------------  --------------------------------------------------------------------------------
-Last updated:           2020-11-06 04:52 UTC
+Last updated:           2020-11-06 04:54 UTC
 Latest batch received:  2020-11-06 04:51 UTC
 Prettier web version:   https://alex.github.io/nyt-2020-election-scraper/battleground-state-changes.html
 ----------------------  --------------------------------------------------------------------------------

--- a/battleground-state-changes.txt
+++ b/battleground-state-changes.txt
@@ -1,5 +1,5 @@
 ----------------------  --------------------------------------------------------------------------------
-Last updated:           2020-11-06 04:54 UTC
+Last updated:           2020-11-06 04:58 UTC
 Latest batch received:  2020-11-06 04:51 UTC
 Prettier web version:   https://alex.github.io/nyt-2020-election-scraper/battleground-state-changes.html
 ----------------------  --------------------------------------------------------------------------------

--- a/notification-updates.json
+++ b/notification-updates.json
@@ -1,1 +1,1 @@
-{"states_updated": ["Pennsylvania"]}
+{"states_updated": []}

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -140,8 +140,13 @@ def compute_hurdle_sma(summarized_state_data, newest_votes, new_partition_pct):
         this_summary = summarized_state_data[step]
         step += 1
         if this_summary.new_votes > 0:
-            agg_votes += this_summary.new_votes
-            agg_c2_votes += round(this_summary.trailing_candidate_partition * this_summary.new_votes)
+            if this_summary.new_votes + agg_votes > MIN_AGG_VOTES:
+                subset_pct = (MIN_AGG_VOTES - agg_votes) / float(this_summary.new_votes)
+                agg_votes += round(this_summary.new_votes * subset_pct)
+                agg_c2_votes += round(this_summary.trailing_candidate_partition * this_summary.new_votes * subset_pct)
+            else:
+                agg_votes += this_summary.new_votes
+                agg_c2_votes += round(this_summary.trailing_candidate_partition * this_summary.new_votes)
 
     if agg_votes:
         hurdle_moving_average = float(agg_c2_votes) / agg_votes
@@ -182,7 +187,7 @@ def html_write_state_head(state: str, state_slug: str, summary: IterationSummary
             <th class="has-tip" data-toggle="tooltip" title="Approximately how many votes are remaining to be counted? These values might be off! Consult state websites and officials for the most accurate and up-to-date figures.">Votes Remaining (est.)</th>
             <th class="has-tip" data-toggle="tooltip" title="How many votes were reported in this block?">Change</th>
             <th class="has-tip" data-toggle="tooltip" title="How did the votes in this block break down, per candidate. Based on the number of reported votes and the change in differential.">Block Breakdown</th>
-            <th class="has-tip" data-toggle="tooltip" title="How has the trailing candidate's share of recent blocks trended? Computed using a moving average of previous 30k or more votes (or as many as available).">Block Trend</th>
+            <th class="has-tip" data-toggle="tooltip" title="How has the trailing candidate's share of recent blocks trended? Computed using a moving average of previous 30k votes.">Block Trend</th>
             <th class="has-tip" data-toggle="tooltip" title="How many precincts have reported?">Precincts Reporting</th>
             <th class="has-tip" data-toggle="tooltip" title="What percentage of the remaining votes does the trailing candidate need to flip the lead. 'Flip' happens at 50%, not at 0%.">Hurdle</th>
         </tr>


### PR DESCRIPTION
…otes. minor math fix

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation
Making a minor math fix per closed issue https://github.com/alex/nyt-2020-election-scraper/issues/148
Occasionally trend computations change dramatically in denominator.
###### Changes
This fix uses a fraction of the necessary block to get to 30k previous votes - thus standardizing the trend comp.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x ] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [ ] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x ] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv` and `*.json` files.
