### PR TITLE
remove initial timestamp flicker

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -85,6 +85,60 @@
     }
     </style>
     <title>Election 2020 Results</title>
+
+    <script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"
+            integrity="sha384-cuApTuVdn64P5ZOzyf+qTgNxGwhvW/ZmdAbNMcl7Q3TkMKJ7/bERQ1cFDmZy7QvZ"
+            crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/dayjs@1.8.21/plugin/utc.js"
+            integrity="sha384-r1JLNIu5SkAfQejSOJPjndnEZkxex5ChJOTaiQeN91L012sA1pyw0A/543Xq97wb"
+            crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/dayjs@1.8.21/plugin/relativeTime.js"
+            integrity="sha384-ojZWhTxW4vjtUz9IjuxEgcPAQQkFj7jlcOnGFp8IyTUTQpFisDT5u8zFh2d0GrSM"
+            crossorigin="anonymous"></script>
+
+    <script type="text/javascript">
+        dayjs.extend(dayjs_plugin_relativeTime)
+        dayjs.extend(dayjs_plugin_utc)
+
+        const prettyTime = timestamp => dayjs.utc(timestamp.replace(" UTC", ""), 'YYYY-MM-DD HH:MM:SS').fromNow()
+
+        const handleNode = node => {
+            if (node.classList && node.classList.contains('timestamp')) {
+                let timestamp;
+                if (node.hasAttribute('data-timestamp')) {
+                    timestamp = node.getAttribute('data-timestamp');
+                } else {
+                    timestamp = node.innerHTML;
+                    node.setAttribute('data-timestamp', timestamp);
+                }
+                node.innerHTML = `<abbr class='pretty-timestamp' title='${timestamp}'>${prettyTime(timestamp)}</abbr>`;
+            }
+        };
+
+        new MutationObserver(mutations => {
+            for (let i = 0, len = mutations.length; i < len; i++) {
+                let added = mutations[i].addedNodes;
+                for (let j = 0, node; (node = added[j]); j++) {
+                    if (node.tagName === 'td') {
+                        handleNode(node);
+                    } else if (node.firstElementChild) {
+                        for (const child of node.getElementsByTagName('td')) {
+                            handleNode(child);
+                        }
+                    }
+                }
+            }
+        }).observe(document, {
+            childList: true,
+            subtree: true,
+        });
+
+        setInterval(() => {
+            $(".pretty-timestamp").map((_, tselem) => {
+                tselem.innerText = prettyTime(tselem.title);
+            });
+        }, 60 * 1000);
+    </script>
 </head>
 
 <body>
@@ -159,23 +213,6 @@
         $(function () {
             $('[data-toggle="tooltip"]').tooltip()
         })
-
-        dayjs.extend(dayjs_plugin_relativeTime)
-        dayjs.extend(dayjs_plugin_utc)
-
-        const prettyTimestamps = () => {
-            $(".timestamp").map(function (idx, tselem) {
-                tselem.innerHTML = "<abbr class='pretty-timestamp' title='" + tselem.innerHTML + "'>" + dayjs.utc(tselem.innerHTML.replace(" UTC", ""), 'YYYY-MM-DD HH:MM:SS').fromNow() + "</abbr>"
-            })
-        };
-        prettyTimestamps();
-        
-        const updateTimestamps = () => {
-            $(".pretty-timestamp").map(function (idx, tselem) {
-                tselem.innerText = dayjs.utc(tselem.title.replace(" UTC", ""), 'YYYY-MM-DD HH:MM:SS').fromNow()
-            })
-        };
-        setInterval(updateTimestamps, 60 * 1000);
 
         const shrinkTablesFeature = 'shrunk';
         feature(shrinkTablesFeature, '#shrink_button', button => {
@@ -274,7 +311,6 @@
                         let currTimestamps = document.getElementById("timestamps");
                         currTimestamps.parentNode.replaceChild(newTimestamps, currTimestamps);
 
-                        prettyTimestamps();
                         refreshFeature(shrinkTablesFeature);
 
                         currentCommit = latestCommit;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation
remove the flicker on page load because of timestamp formatting

###### Changes
use a mutationobserver to update the dom elements as they're being loaded

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv` and `*.json` files.
