### PR TITLE
Fix Notification typo, calculate interval

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -260,8 +260,17 @@
             let currentCommit = await fetchLatestCommit();
             console.log("current commit", currentCommit);
 
+            function nextCheck(){
+                const ONE_MINUTE = 1 * 60 * 1000;
+                const FIVE_MINUTES = 5 * ONE_MINUTE;
+                const now = new Date();
+                const lastUpdate = new Date(currentCommit.commit.author.date);
+                // check at most every minute
+                return Math.max(ONE_MINUTE, FIVE_MINUTES - (now - lastUpdate));
+            }
+
             // live updates
-            setInterval(async function() {
+            async function getUpdates() {
                 if (!isFeatureEnabled(liveUpdatesFeature)) return;
 
                 let latestCommit = await fetchLatestCommit();
@@ -285,12 +294,14 @@
                         refreshFeature(shrinkTablesFeature);
 
                         currentCommit = latestCommit;
-                        if (Notifcation.permission === "granted") {
+                        if (Notification.permission === "granted") {
                             new Notification(`New ballots were counted in: ${latestContent.updates.states_updated.join(", ")}!`);
                         }
                     }
                 }
-            }, 5 * 60 * 1000);
+                setTimeout(getUpdates, nextCheck());
+            }
+            setTimeout(getUpdates, nextCheck());
         })();
     </script>
 </body>


### PR DESCRIPTION
Change `Notifcation` to `Notification` to fix ReferenceError and make
notifications work

Change `setInterval(..., 5 * 60 * 1000)` to `setTimeout`, and set the timeout
to a calculated number of milliseconds so that the page is updated when the
repo actually changes, rather than 5 minutes after the page loaded. Fall back
to a 1 minute interval if the repo hasn't updated on time.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation
The update check happens 5 minutes after the page is loaded, regardless of
when the last commit happened. This can lead to nearly 10 minutes before the
first refresh happens.

###### Changes

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv` and `*.json` files.
