### PR TITLE
this adds a ✅ or a ❌ depending on if the candidate did or didn't clear the hurdle

### DIFF
--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -122,7 +122,8 @@ IterationSummary = collections.namedtuple(
         'precincts_total',
         'hurdle',
         'hurdle_change',
-        'hurdle_mov_avg'
+        'hurdle_mov_avg',
+        'hurdle_success',
     ]
 )
 
@@ -229,7 +230,7 @@ def html_summary(summary: IterationSummary):
 
     html += f'''
             <td><abbr title="{summary.precincts_reporting}/{summary.precincts_total}">{summary.precincts_reporting/summary.precincts_total:.1%}</abbr></td>
-            <td>{summary.trailing_candidate_name} needs {summary.hurdle:.2%} [{summary.hurdle_change:.3%}]</td>
+            <td>{summary.hurdle_success} {summary.trailing_candidate_name} needs {summary.hurdle:.2%} [{summary.hurdle_change:.3%}]</td>
         </tr>
     '''
 
@@ -282,6 +283,7 @@ def json_to_summary(
 
     # Compute aggregate of last 5 hurdle, if available
     hurdle_mov_avg = compute_hurdle_sma(summarized[state_name], new_votes, repartition1 if new_votes else 0)
+    hurdle_success = "" if not hurdle_mov_avg else ("✅" if hurdle_mov_avg > hurdle else "❌")
 
     summary = IterationSummary(
         batch_time,
@@ -298,7 +300,8 @@ def json_to_summary(
         precincts_total,
         hurdle,
         hurdle-last_iteration_info.hurdle,
-        hurdle_mov_avg
+        hurdle_mov_avg,
+        hurdle_success
     )
 
     return iteration_info, summary


### PR DESCRIPTION


###### Motivation
It's nice to see at a glance if a particular dump did or didn't clear the hurdle.

A bit of discussion in #156
###### Changes
<img width="1086" alt="Election 2020 Results 2020-11-05 23-24-02" src="https://user-images.githubusercontent.com/368544/98329556-174b7300-1fbe-11eb-9569-e34acbdc6658.png">

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [X] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [X] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [X] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv` and `*.json` files.
