### PR TITLE
Add toggle to show/hide each state table

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -23,6 +23,11 @@
         margin: 1rem;
     }
     
+    .table.hide thead .state-table-header,
+    .table.hide tbody {
+        display: none;
+    }
+
     .table td, .table th {
         padding: .25rem .5rem;
     }
@@ -246,6 +251,22 @@
             button.html('Shrink Tables');
             $('.table').each(function() { $(this).find('tbody tr').show(); });
         });
+    </script>
+
+    <script type="text/javascript">
+        // Toggle visibility of the state tables
+        function toggleState(stateSlug) {
+            const stateTable = document.getElementById(stateSlug);
+            const stateButton = stateTable.getElementsByTagName('button')[0];
+
+            if (stateTable.classList.contains("hide")) {
+                stateTable.classList.remove("hide");
+                stateButton.innerHTML = 'Hide';
+            } else {
+                stateTable.classList.add("hide");
+                stateButton.innerHTML = 'Show';
+            }
+        }
     </script>
 
     <script type="text/javascript">

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -187,16 +187,17 @@ def string_summary(summary):
 def html_write_state_head(state: str, state_slug: str, summary: IterationSummary):
     return f'''
         <thead class="thead-light">
-        <tr>
+        <tr class="state-summary">
             <td class="text-left flag-bg" style="background-image: url('flags/{state_slug}.svg')" colspan="9">
                 <span class="has-tip" data-toggle="tooltip" title="Number of electoral votes contributed by this state and total votes by each candidate.">
                     <span class="statename">{state}</span>
                 </span>
+                <button type="button" class="btn btn-outline-secondary btn-sm pull-right" onclick="toggleState('{state_slug}')">Hide</button>
                 <br>
                 Total Votes: {summary.leading_candidate_name} leads with {summary.leading_candidate_votes:,} votes, {summary.trailing_candidate_name} trails with {summary.trailing_candidate_votes:,} votes.
             </td>
         </tr>
-        <tr>
+        <tr class="state-table-header">
             <th class="has-tip" data-toggle="tooltip" title="When did this block of votes get reported?">Timestamp</th>
             <th class="has-tip" data-toggle="tooltip" title="Which candidate currently leads this state?">In The Lead</th>
             <th class="has-tip" data-toggle="tooltip" title="How many votes separate the two candidates?">Vote Differential</th>


### PR DESCRIPTION
Add a toggle button to the state summary header to show/hide the complete data table.

Resolves #133 

Expanded:
![133-expanded](https://user-images.githubusercontent.com/22353962/98329797-08b58980-1fc7-11eb-9ab0-d24cae30eb84.png)

Collapsed:
![133-collapsed](https://user-images.githubusercontent.com/22353962/98329792-06ebc600-1fc7-11eb-8175-8b4c8b537026.png)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation

###### Changes

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [X] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [X] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [X] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv` and `*.json` files.
