### PR TITLE
Add recent updates (past hour) summary

### DIFF
--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -24,6 +24,7 @@ STATE_INDEXES = [AK_INDEX, AZ_INDEX, GA_INDEX, NC_INDEX, NV_INDEX, PA_INDEX]
 CACHE_DIR = '_cache'
 # Bump this with any changes to `fetch_all_records`
 CACHE_VERSION = 1
+RECENCY_SUMMARY_THRESHOLD_MINS = datetime.timedelta(minutes = 60)
 
 def git_commits_for(path):
     return subprocess.check_output(['git', 'log', "--format=%H", path]).strip().decode().splitlines()
@@ -152,6 +153,28 @@ def compute_hurdle_sma(summarized_state_data, newest_votes, new_partition_pct):
         hurdle_moving_average = float(agg_c2_votes) / agg_votes
 
     return hurdle_moving_average
+
+def get_recent_updates(state_records):
+    recent_updates = []
+    now = datetime.datetime.utcnow()
+    for state, val in state_records.items():
+        for row in val:
+            if now - row.timestamp < RECENCY_SUMMARY_THRESHOLD_MINS:
+                recent_updates.append((state, row))
+    return recent_updates
+
+def recent_updates_to_str(recent_updates):
+    # Guard clause: No recent updates, avoid bothering any processing/formatting.
+    if not recent_updates:
+        return 'No updates in the past hour.'
+
+    state_counts = collections.defaultdict(int)
+    for state, update in recent_updates:
+        state_counts[state] += 1
+    state_counts_str = " ".join(
+        ['{} new data point(s) for {}.'.format(v, k) for k, v in state_counts.items()])
+
+    return f'Updates in the past hour: {state_counts_str}'.strip()
 
 
 def string_summary(summary):
@@ -371,8 +394,13 @@ for (state, timestamped_results) in summarized.items():
     html_chunks.append("</table><hr>")
 
 with open("battleground-state-changes.html","w", encoding='utf8') as f:
-    html = html_template.replace('{% TABLES %}', "\n".join(html_chunks)).replace('{% SCRAPE_TIME %}', scrape_time.strftime('%Y-%m-%d %H:%M:%S UTC')).replace('{% BATCH_TIME %}', batch_time.strftime('%Y-%m-%d %H:%M:%S UTC'))
+    html = html_template \
+        .replace('{% TABLES %}', "\n".join(html_chunks)) \
+        .replace('{% SCRAPE_TIME %}', scrape_time.strftime('%Y-%m-%d %H:%M:%S UTC')) \
+        .replace('{% BATCH_TIME %}', batch_time.strftime('%Y-%m-%d %H:%M:%S UTC'))
     f.write(html)
+
+print(recent_updates_to_str(get_recent_updates(summarized)))
 
 with open('battleground-state-changes.csv', 'w') as csvfile:
     wr = csv.writer(csvfile)


### PR DESCRIPTION
Shows a summary of the updates in the past 60 minutes, and to which states those
updates belong. Was planning to integrate with the html page, but putting that
off for now as it didn't integrate nicely with the auto-update feature which was
recently merged.

Idea was to put a nice little summary at the top, to display any recent updates,
rather than scrolling around looking for the latest rows.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation

###### Changes

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv` and `*.json` files.
