### PR TITLE
move the info icon up

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -327,7 +327,9 @@
         };
 
         // do an initial update
-        updateCheck({}, false);
+        if (!isDeveloperEnvironment()) {
+            updateCheck({}, false);
+        }
 
         const startLiveUpdates = async () => {
             let currentCommit = await fetchLatestCommit();

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -182,8 +182,8 @@ def html_write_state_head(state: str, state_slug: str, summary: IterationSummary
     return f'''
         <thead class="thead-light">
         <tr>
-            <td class="text-left has-tip flag-bg" style="background-image: url('flags/{state_slug}.svg')" colspan="9">
-                <span data-toggle="tooltip" title="Number of electoral votes contributed by this state and total votes by each candidate.">
+            <td class="text-left flag-bg" style="background-image: url('flags/{state_slug}.svg')" colspan="9">
+                <span class="has-tip" data-toggle="tooltip" title="Number of electoral votes contributed by this state and total votes by each candidate.">
                     <span class="statename">{state}</span>
                 </span>
                 <br>


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation
the icon was misleading
###### Changes
moved the icon. also disabled force refresh on dev environments so you can actually test this

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
![image](https://user-images.githubusercontent.com/10292550/98337249-538acd80-1fd6-11eb-96d2-090a97940086.png)

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv` and `*.json` files.
