### PR TITLE
Fix info icon

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -60,6 +60,7 @@
 
     .has-tip:after{
         content: "\2139\fe0f";
+        font-family: Arial, sans-serif;
         margin-left: 5px;
     }
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation

For Chrome/Firefox/Opera on macOS, the info icon shows up as an "i":

![image](https://user-images.githubusercontent.com/1324225/98338901-8f905380-2013-11eb-9dbf-f31c5d6afef6.png)

It's okay for Safari on macOS and Chrome on Android.

###### Changes

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repx's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv` and `*.json` files.

Specify Arial/sans-serif for the font so it can show the icon.

Fixes Chrome/Firefox/Opera on macOS, doesn't break Safari on macOS:

![image](https://user-images.githubusercontent.com/1324225/98338934-9a4ae880-2013-11eb-9244-d444f08a555e.png)


