### PR TITLE
hide tooltips before updating dom

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -308,6 +308,8 @@
                 if (newHash && newHash !== currentHash && !isDeveloperEnvironment()) {
                     location.reload(true);
                 } else {
+                    $('[data-toggle="tooltip"]').tooltip('hide')
+
                     const elementsToUpdate = [
                         ...Array.from(document.getElementsByTagName("table")),
                         document.getElementById("timestamps"),


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation
bootstrap tooltips are dom elements, and if we do a refresh bootstrap doesn't know how to deal with it and just leaves it in the window. refreshes happen without any indication to the user so it would really suck if a tooltip was blocking their view. of course, the alternative is that now a tooltip might magically vanish from underneath them, but it's easier to get a tooltip back than to make it go away
###### Changes
hide all tooltips before refreshing the dom

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv` and `*.json` files.
