### PR TITLE
also consider if results.json changed

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -287,7 +287,7 @@
             return location.protocol === 'file:' || location.hostname === 'localhost' || location.hostname === '127.0.0.1';
         };
 
-        const updateCheck = async (currentCommit, notify) => {
+        const updateCheck = async (currentCommit, currentContent) => {
             let latestCommit = await fetchLatestCommit();
             console.log("latest commit", latestCommit);
 
@@ -296,7 +296,10 @@
                 let latestContent = await fetchLatestContent(latestCommit['sha']);
 
                 console.log("latest content", latestContent.updates);
-                if (notify && latestContent.updates.states_updated.length) {
+                if (currentContent &&
+                    currentContent.updates.results_hash !== latestContent.updates.results_hash &&
+                    latestContent.updates.states_updated.length
+                ) {
                     if (Notification.permission === "granted") {
                         new Notification(`New ballots were counted in: ${latestContent.updates.states_updated.join(", ")}!`);
                     }
@@ -323,19 +326,23 @@
                     loadTooltips();
                     refreshFeature(shrinkTablesFeature);
                 }
+
+                return {commit: latestCommit, content: latestContent};
             }
 
-            return latestCommit;
+            return {commit: latestCommit, content: currentContent};
         };
 
         // do an initial update
         if (!isDeveloperEnvironment()) {
-            updateCheck({}, false);
+            updateCheck({}, undefined);
         }
 
         const startLiveUpdates = async () => {
             let currentCommit = await fetchLatestCommit();
             console.log("current commit", currentCommit);
+            let currentContent = await fetchLatestContent(currentCommit['sha']);
+            console.log("current content", currentContent.updates);
 
             const nextCheck = () => {
                 const ONE_MINUTE = 1 * 60 * 1000;
@@ -349,8 +356,11 @@
             const runner = async () => {
                 if (!isFeatureEnabled(liveUpdatesFeature)) return;
 
-                currentCommit = await updateCheck(currentCommit, true);
+                const results = await updateCheck(currentCommit, currentContent);
+                currentCommit = results.commit;
+                currentContent = results.content;
                 console.log("new current commit", currentCommit);
+                console.log("new current content", currentContent);
                 setTimeout(runner, nextCheck());
             };
 

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -350,6 +350,9 @@ with open("battleground-state-changes.html.tmpl", "r", encoding='utf8') as f:
     html_template += f.read()
 TEMPLATE_HASH = hashlib.sha256(html_template.encode('utf8')).hexdigest()
 
+with open("results.json", "r", encoding='utf8') as f:
+    RESULTS_HASH = hashlib.sha256(f.read().encode('utf8')).hexdigest()
+
 html_chunks = []
 
 batch_time = max(itertools.chain.from_iterable(summarized.values()), key=lambda s: s.timestamp).timestamp
@@ -383,5 +386,6 @@ with open('battleground-state-changes.csv', 'w') as csvfile:
 
 with open("notification-updates.json", "w") as f:
     f.write(json.dumps({
-        "states_updated": [],
+        "results_hash": RESULTS_HASH,
+        "states_updated": states_updated,
     }))


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation
now that we're pushing stuff past midnight, polls aren't updating and results.json isn't changing which revealed an edge case: if the last change to results.json was a state we cared about and then nothing ever changes, then we'll keep thinking that the state was updated even if it wasn't.

the solution is to only notify users if results.json also changed (which should imply that either a state we cared about got a new block, or it didn't).

i already made the gaslighting joke once so i cant make it again.

###### Changes
check whether the result hash changed before notifying users

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv` and `*.json` files.
