### PR TITLE
Enhancement: added latest batch button and row highlighting

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -70,6 +70,17 @@
         background-position: 100%;
     }
 
+    .btn-group-xs > .btn, .btn-xs {
+        padding: .25rem .4rem;
+        font-size: .875rem;
+        line-height: .5;
+        border-radius: .2rem;
+      }
+
+    .highlight {
+        background-color: #FFFFE0;
+    }
+
     .Biden{
         background-color: #84C4EE
     }
@@ -167,6 +178,7 @@
     </p>
 
     <p class="float-left" id="timestamps">Last scrape: <span class="timestamp">{% SCRAPE_TIME %}</span> | Last batch: <span class="timestamp">{% BATCH_TIME %}</span></p>
+    <button type="button" id="latest_batch" class="btn btn-primary btn-xs">Latest</button>
     <div id="template-hash" style="display: none;">{% TEMPLATE_HASH %}</div>
 
     <p class="float-right">
@@ -364,6 +376,17 @@
             startLiveUpdates();
         }, button => {
             button.html('Enable Live Updates');
+        });
+    </script>
+
+    <script type="text/javascript">
+        $("#latest_batch").click(function(){
+            var latest_timestamp = document.querySelectorAll('p .timestamp')[1].getAttribute('data-timestamp');
+            var row_timestamp = document.querySelector('tbody td[data-timestamp="'+ latest_timestamp +'"]');
+
+            row_timestamp.scrollIntoView();
+            $(row_timestamp.parentNode).addClass('highlight');
+            setTimeout(function () { $(row_timestamp.parentNode).removeClass('highlight'); }, 3000);
         });
     </script>
 </body>


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation
**Enhancement:**  add a 'Latest' button for the latest batch results to highlight and take you to the latest batch entry row.

![latest button](https://user-images.githubusercontent.com/6217039/98349383-eaac5100-1fe7-11eb-9bcf-5743cc8868fc.PNG)
![highlighted row](https://user-images.githubusercontent.com/6217039/98349396-eda74180-1fe7-11eb-8701-6647bcdcb200.PNG)


###### Changes

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv` and `*.json` files.
