### PR TITLE
Update new_votes to actually calculate new votes

### DIFF
--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -289,6 +289,8 @@ def json_to_summary(
     iteration_info = IterationInfo(
         vote_diff=vote_diff,
         votes=votes,
+        candidate1_votes=candidate1_votes,
+        candidate2_votes=candidate2_votes,
         precincts_reporting=precincts_reporting,
         hurdle=hurdle,
         leading_candidate_name=candidate1_name

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -275,7 +275,7 @@ def json_to_summary(
     votes_remaining = expected_votes - votes
     precincts_reporting = row.precincts_reporting
     precincts_total = row.precincts_total
-    new_votes = 0 if last_iteration_info.votes is None else (votes - last_iteration_info.votes)
+    new_votes = (candidate1_votes + candidate2_votes) - (last_iteration_info.candidate1_votes + last_iteration_info.candidate2_votes)
 
     hurdle = (vote_diff + (votes_remaining * (candidate1_votes + candidate2_votes)) / votes) / (2 * votes_remaining) if votes_remaining > 0 else 0
 

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -333,6 +333,8 @@ for rows in records.values():
         precincts_reporting=None,
         hurdle=0,
         leading_candidate_name=None
+        candidate1_votes=0,
+        candidate2_votes=0
     )
 
     for row in rows:


### PR DESCRIPTION
Updates new_votes to calculate the new votes coming in instead of basing it on estimated remaining votes.

This _should_ fix the issue seen 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation

###### Changes

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [ ] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [ ] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [ ] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv` and `*.json` files.
