### PR TITLE
poll gh pages

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -156,7 +156,7 @@
 </head>
 
 <body>
-<div class="container-fluid">
+<div id="body" class="container-fluid">
     <div class="row">
         <div class="col-sm">
             <p style="font-size: 1.4rem;">
@@ -171,6 +171,7 @@
         <div class="col-sm">
             <p class="float-left" id="timestamps">Last scrape: <span class="timestamp">{% SCRAPE_TIME %}</span> | Last batch: <span class="timestamp">{% BATCH_TIME %}</span></p>
             <div id="template-hash" style="display: none;">{% TEMPLATE_HASH %}</div>
+            <div id="page-metadata" style="display: none;">{% PAGE_METADATA %}</div>
         </div>
         <div class="col-sm">
             <p class="float-right">
@@ -258,126 +259,99 @@
     </script>
 
     <script type="text/javascript">
-        const fetchLatestCommit = async () => {
-            const response = await fetch("https://api.github.com/repos/alex/nyt-2020-election-scraper/commits?per_page=10", {
-                cache: 'no-cache',
-                headers: {
-                    accept: 'application/vnd.github.v3+json',
-                },
-            });
-            const body = await response.json();
-            for (var i = 0; i < body.length; i++) {
-                if (body[i]['commit']['author']['email'] === 'actions@users.noreply.github.com' &&
-                    body[i]['commit']['message'] === 'Regenerate battleground-state-changes.txt/html') {
-                    return body[i];
-                }
-            }
-            return body[0]; // oh well, default to latest
-        };
-
-        const fetchLatestContent = async (sha) => {
-            const contentResponse = await fetch(`https://raw.githubusercontent.com/alex/nyt-2020-election-scraper/${sha}/battleground-state-changes.html`, {
+        // grab the latest html and return it as a Document
+        const fetchLatestContent = async () => {
+            const contentResponse = await fetch(location.toString(), {
                 cache: 'no-cache',
             });
             const contentBody = await contentResponse.text();
             const contentDom = new DOMParser().parseFromString(contentBody, 'text/html');
 
-            const updatesResponse = await fetch(`https://raw.githubusercontent.com/alex/nyt-2020-election-scraper/${sha}/notification-updates.json`, {
-                cache: 'no-cache',
-            });
-            const updatesBody = await updatesResponse.json();
+            let contentMetadata;
+            if (contentDom.getElementById("page-metadata")) {
+                contentMetadata = JSON.parse(contentDom.getElementById("page-metadata").innerText);
+            } else {
+                contentMetadata = {
+                    template_hash: contentDom.getElementById("template-hash").innerText,
+                };
+            }
             return {
-                updates: updatesBody,
+                metadata: contentMetadata,
                 dom: contentDom,
-            };
+            }
         };
 
+        // check if the current host is a development host
         const isDeveloperEnvironment = () => {
             return location.protocol === 'file:' || location.hostname === 'localhost' || location.hostname === '127.0.0.1';
         };
 
-        const updateCheck = async (currentCommit, currentContent) => {
-            let latestCommit = await fetchLatestCommit();
-            console.log("latest commit", latestCommit);
+        // if the new page has notifications, show them
+        // if the new page is an updated template, hard refresh (which should get us the new page since we just loaded it)
+        // otherwise, replace the div id=body element
+        const updateCheck = async currentMetadata => {
+            const latestContent = await fetchLatestContent();
+            const latestMetadata = latestContent.metadata;
+            const latestDom = latestContent.dom;
+            console.log("latest content", latestContent);
 
-            if (currentCommit['sha'] !== latestCommit['sha']) {
-                console.log("updating to", latestCommit);
-                let latestContent = await fetchLatestContent(latestCommit['sha']);
-
-                console.log("latest content", latestContent.updates);
-                if (currentContent &&
-                    currentContent.updates.results_hash !== latestContent.updates.results_hash &&
-                    latestContent.updates.states_updated.length
-                ) {
-                    if (Notification.permission === "granted") {
-                        const notification = new Notification(`New ballots were counted in: ${latestContent.updates.states_updated.join(", ")}!`);
-                        notification.onclick = function (event) {
-                            // focus page
-                            window.parent.focus(); 
-                            // just in case, older browsers
-                            window.focus(); 
-                            // dismiss notification
-                            event.target.close(); 
-                        };
-                    }
+            if (
+                currentMetadata &&
+                currentMetadata.results_hash !== latestMetadata.results_hash &&
+                latestMetadata.states_updated.length
+            ) {
+                if (Notification.permission === "granted") {
+                    const notification = new Notification(`New ballots were counted in: ${latestMetadata.states_updated.join(", ")}!`);
+                    notification.onclick = function (event) {
+                        // focus page
+                        window.parent.focus();
+                        // just in case, older browsers
+                        window.focus();
+                        // dismiss notification
+                        event.target.close();
+                    };
                 }
-
-                let newHash = latestContent.dom.getElementById("template-hash")?.innerText;
-                let currentHash = document.getElementById("template-hash").innerText;
-
-                if (newHash && newHash !== currentHash && !isDeveloperEnvironment()) {
-                    location.reload(true);
-                } else {
-                    $('[data-toggle="tooltip"]').tooltip('hide')
-
-                    const elementsToUpdate = [
-                        ...Array.from(document.getElementsByTagName("table")),
-                        document.getElementById("timestamps"),
-                    ];
-
-                    elementsToUpdate.forEach(oldElement => {
-                        let newElement = latestContent.dom.getElementById(oldElement.id);
-                        oldElement.parentNode.replaceChild(newElement, oldElement);
-                    });
-
-                    loadTooltips();
-                    refreshFeature(shrinkTablesFeature);
-                }
-
-                return {commit: latestCommit, content: latestContent};
             }
 
-            return {commit: latestCommit, content: currentContent};
+            if (
+                currentMetadata &&
+                currentMetadata.template_hash !== latestMetadata.template_hash
+            ) {
+                console.log("new template, forcing reload");
+                location.reload(true);
+            }
+
+            $('[data-toggle="tooltip"]').tooltip('hide')
+
+            let newBody = latestDom.getElementById('body');
+            let curBody = document.getElementById('body');
+            curBody.parentNode.replaceChild(newBody, curBody);
+
+            loadTooltips();
+            refreshFeature(shrinkTablesFeature);
+
+            return latestContent.metadata;
         };
 
-        // do an initial update
-        if (!isDeveloperEnvironment()) {
-            updateCheck({}, undefined);
-        }
+        // do a test update
+        updateCheck(undefined);
 
         const startLiveUpdates = async () => {
-            let currentCommit = await fetchLatestCommit();
-            console.log("current commit", currentCommit);
-            let currentContent = await fetchLatestContent(currentCommit['sha']);
-            console.log("current content", currentContent.updates);
+            let currentMetadata = (await fetchLatestContent()).metadata;
+            console.log("current content", currentMetadata);
 
             const nextCheck = () => {
-                const ONE_MINUTE = 1 * 60 * 1000;
-                const FIVE_MINUTES = 5 * ONE_MINUTE;
-                const now = new Date();
-                const lastUpdate = new Date(currentCommit.commit.author.date);
-                // check at most every minute
-                return Math.max(ONE_MINUTE, FIVE_MINUTES - (now - lastUpdate));
+                return isDeveloperEnvironment() ? 5 * 1000 : 60 * 1000;
             };
 
             const runner = async () => {
                 if (!isFeatureEnabled(liveUpdatesFeature)) return;
 
-                const results = await updateCheck(currentCommit, currentContent);
-                currentCommit = results.commit;
-                currentContent = results.content;
-                console.log("new current commit", currentCommit);
-                console.log("new current content", currentContent);
+                try {
+                    currentMetadata = await updateCheck(currentMetadata);
+                } catch (e) {
+                    console.log("failed to check for updates", e);
+                }
                 setTimeout(runner, nextCheck());
             };
 

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -436,8 +436,10 @@ with open('battleground-state-changes.xml', 'w') as rssfile:
 </rss>
 ''')
 
+# this file is deprecated and should not be used! it will be removed soontm
 with open("notification-updates.json", "w") as f:
     f.write(json.dumps({
+        "_comment": "this file is deprecated and should not be used",
         "results_hash": RESULTS_HASH,
         "states_updated": states_updated,
     }))

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -387,7 +387,18 @@ for (state, timestamped_results) in sorted(summarized.items()):
     html_chunks.append("</table></div><hr>")
 
 with open("battleground-state-changes.html","w", encoding='utf8') as f:
-    html = html_template.replace('{% TABLES %}', "\n".join(html_chunks)).replace('{% SCRAPE_TIME %}', scrape_time.strftime('%Y-%m-%d %H:%M:%S UTC')).replace('{% BATCH_TIME %}', batch_time.strftime('%Y-%m-%d %H:%M:%S UTC')).replace('{% TEMPLATE_HASH %}', TEMPLATE_HASH)
+    page_metadata = json.dumps({
+        "template_hash": TEMPLATE_HASH,
+        "results_hash": RESULTS_HASH,
+        "states_updated": states_updated,
+    })
+
+    html = html_template\
+        .replace('{% TABLES %}', "\n".join(html_chunks))\
+        .replace('{% SCRAPE_TIME %}', scrape_time.strftime('%Y-%m-%d %H:%M:%S UTC'))\
+        .replace('{% BATCH_TIME %}', batch_time.strftime('%Y-%m-%d %H:%M:%S UTC'))\
+        .replace('{% TEMPLATE_HASH %}', TEMPLATE_HASH)\
+        .replace('{% PAGE_METADATA %}', page_metadata)
     f.write(html)
 
 with open('battleground-state-changes.csv', 'w') as csvfile:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation
now that we have rich metadata, let's kill the complexity introduced by having to rely on git commits to determine when a change was made

###### Changes
- poll every minute to account for variable github pages cache update delay
- poll the current url to make forking/dev testing easier
- removed old commit checking logic
- should fix #198 
- also prevents the possibility of hitting the gh api rate limit
- deprecate the notification updates json file

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
