### PR TITLE
revert page update logic

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -331,9 +331,15 @@
 
             $('[data-toggle="tooltip"]').tooltip('hide')
 
-            let newBody = latestDom.getElementById('body');
-            let curBody = document.getElementById('body');
-            curBody.parentNode.replaceChild(newBody, curBody);
+            const elementsToUpdate = [
+                ...Array.from(document.getElementsByTagName("table")),
+                document.getElementById("timestamps"),
+            ];
+
+            elementsToUpdate.forEach(oldElement => {
+                let newElement = latestContent.dom.getElementById(oldElement.id);
+                oldElement.parentNode.replaceChild(newElement, oldElement);
+            });
 
             loadTooltips();
             refreshFeature(shrinkTablesFeature);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation
i broke the buttons help

i wanted to simplify the page update logic so that it just wipes out the entire div and replaces it anew, since that felt cleaner than the current implementation of "here's 8 special element ids to replace", but that wiped the eventhandlers on the buttons since this isn't react

###### Changes
go back to the old update algorithm and just leave it be

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
![image](https://user-images.githubusercontent.com/10292550/98396684-1e10cf00-202c-11eb-87e0-44dfa3d80ae7.png)

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
