### PR TITLE
Fix tooltip overflow issue

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -239,7 +239,7 @@
     <script type="text/javascript">
         const loadTooltips = () => {
             $(function () {
-                $('[data-toggle="tooltip"]').tooltip()
+                $('[data-toggle="tooltip"]').tooltip({ boundary: 'window' })
             })
         };
         loadTooltips();


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation
Tooltips with long text are overflowing their bounding box, leading to a rapid flicker. 

###### Changes
Adjusts the tooltip boundary.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [X] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [ ] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [X] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
