### PR TITLE
fix local timestamps for certain timezones

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -123,6 +123,7 @@
         dayjs.extend(dayjs_plugin_timezone)
 
         const prettyTime = timestamp => dayjs.utc(timestamp.replace(" UTC", ""), 'YYYY-MM-DD HH:MM:SS').fromNow()
+        const localTime = timestamp => dayjs.utc(timestamp.replace(" UTC", ""), 'YYYY-MM-DD HH:MM:SS').local().format('DD MMM YYYY h:mm:ss A z');
 
         const handleNode = node => {
             if (node.classList && node.classList.contains('timestamp')) {
@@ -130,10 +131,10 @@
                 if (node.hasAttribute('data-timestamp')) {
                     timestamp = node.getAttribute('data-timestamp');
                 } else {
-                    timestamp = dayjs.utc(node.innerHTML.replace(" UTC", ""), 'YYYY-MM-DDTHH:MM:SS').local().format('DD MMM YYYY h:mm:ss A z');
+                    timestamp = node.innerHTML;
                     node.setAttribute('data-timestamp', timestamp);
                 }
-                node.innerHTML = `<abbr class='pretty-timestamp' title='${timestamp}'>${prettyTime(timestamp)}</abbr>`;
+                node.innerHTML = `<abbr class='pretty-timestamp' title='${localTime(timestamp)}'>${prettyTime(timestamp)}</abbr>`;
             }
         };
 
@@ -157,7 +158,7 @@
 
         setInterval(() => {
             $(".pretty-timestamp").map((_, tselem) => {
-                tselem.innerText = prettyTime(tselem.title);
+                tselem.innerText = prettyTime(tselem.parentElement.getAttribute("data-timestamp"));
             });
         }, 60 * 1000);
     </script>


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation
#266 

###### Changes
test this by going in chrome devtools, opening the dot menu, selecting more tools, sensors, then overriding the timezone with `America/Anchorage`. it should fail with NaN on master but succeed on this branch

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
![image](https://user-images.githubusercontent.com/10292550/98401022-038e2400-2033-11eb-9238-8fcbf16f4965.png)

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
