### PR TITLE
notify after refresh

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -298,36 +298,36 @@
         // if the new page has notifications, show them
         // if the new page is an updated template, hard refresh (which should get us the new page since we just loaded it)
         // otherwise, replace the div id=body element
-        const updateCheck = async currentMetadata => {
+        const updateCheck = async (currentMetadata, forceNotify) => {
             const latestContent = await fetchLatestContent();
             const latestMetadata = latestContent.metadata;
             const latestDom = latestContent.dom;
             console.log("latest content", latestContent);
 
-            if (
-                currentMetadata &&
-                currentMetadata.results_hash !== latestMetadata.results_hash &&
-                latestMetadata.states_updated.length
-            ) {
-                if (Notification.permission === "granted") {
-                    const notification = new Notification(`New ballots were counted in: ${latestMetadata.states_updated.join(", ")}!`);
-                    notification.onclick = function (event) {
-                        // focus page
-                        window.parent.focus();
-                        // just in case, older browsers
-                        window.focus();
-                        // dismiss notification
-                        event.target.close();
-                    };
+            let shouldNotify = latestMetadata.states_updated.length && (
+                forceNotify ||
+                (currentMetadata && currentMetadata.results_hash !== latestMetadata.results_hash)
+            );
+
+            if (currentMetadata && currentMetadata.template_hash !== latestMetadata.template_hash) {
+                console.log("new template, forcing reload");
+                if (shouldNotify) {
+                    location.hash = "notify";
                 }
+                location.reload(true);
+                return;
             }
 
-            if (
-                currentMetadata &&
-                currentMetadata.template_hash !== latestMetadata.template_hash
-            ) {
-                console.log("new template, forcing reload");
-                location.reload(true);
+            if (shouldNotify && Notification.permission === "granted") {
+                const notification = new Notification(`New ballots were counted in: ${latestMetadata.states_updated.join(", ")}!`);
+                notification.onclick = function (event) {
+                    // focus page
+                    window.parent.focus();
+                    // just in case, older browsers
+                    window.focus();
+                    // dismiss notification
+                    event.target.close();
+                };
             }
 
             $('[data-toggle="tooltip"]').tooltip('hide')
@@ -349,7 +349,8 @@
         };
 
         // do a test update
-        updateCheck(undefined);
+        updateCheck(undefined, location.hash === '#notify');
+        location.hash = "";
 
         const startLiveUpdates = async () => {
             let currentMetadata = (await fetchLatestContent()).metadata;
@@ -363,7 +364,7 @@
                 if (!isFeatureEnabled(liveUpdatesFeature)) return;
 
                 try {
-                    currentMetadata = await updateCheck(currentMetadata);
+                    currentMetadata = await updateCheck(currentMetadata, false);
                 } catch (e) {
                     console.log("failed to check for updates", e);
                 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation
if the window is refreshed after a notification is popped, clicking the notification won't take the user to the page

###### Changes
use the location hash to store whether to show a notification on page load, and update the hash before reloading if we need to show a notification

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
