### PR TITLE
fix: keep borders on left- and rightmost headers for spacing reasons

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -54,9 +54,15 @@
         position: sticky;
         /* Padding, first line, second line, padding */
         top: calc(.25rem + 1.2rem + 1.2rem + .25rem);
-        border-right: none;
-        border-left: none;
-        border-top: none;
+        border-right-width: 0;
+        border-left-width: 0;
+        border-top-width: 0;
+    }
+    thead tr:nth-child(2) th:first-child {
+        border-left-width: 1px;
+    }
+    thead tr:nth-child(2) th:last-child {
+        border-right-width: 1px;
     }
 
     .has-tip {


### PR DESCRIPTION
###### Motivation

There's a one-pixel gap on the second table header at the start and end of it.

###### Changes

Add back the left- and rightmost borders.

Old:
![Screenshot from 2020-11-06 13-37-27](https://user-images.githubusercontent.com/29508/98407481-62ed3380-2035-11eb-80d5-2106cecaf439.png)

New:
![Screenshot from 2020-11-06 13-38-12](https://user-images.githubusercontent.com/29508/98407494-67195100-2035-11eb-8ad8-9cdede37871b.png)

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
