### PR TITLE
fix alignment on timestamp column

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -25,7 +25,7 @@
     }
 
     .timestamp {
-      min-width: 13rem;
+      min-width: 8rem;
     }
     
     .table td, .table th {

--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -23,6 +23,10 @@
     .table-responsive.table-responsive {
       overflow-x: unset;
     }
+
+    .timestamp {
+      min-width: 13rem;
+    }
     
     .table td, .table th {
         padding: .25rem .5rem;


### PR DESCRIPTION
adds a `min-width` to `.timestamp` CSS

![Screen Shot 2020-11-06 at 5 19 58 PM](https://user-images.githubusercontent.com/10540830/98420028-53c9ae00-2054-11eb-8ebd-1e52929724c1.png)
