### PR TITLE
show Unknown when the votes remaining are < 0

### DIFF
--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -174,14 +174,16 @@ def string_summary(summary):
 
     lead_part = summary.leading_candidate_partition - 50
 
+    visible_hurdle = f'{summary.trailing_candidate_name} needs {summary.hurdle:.2%} [{summary.hurdle_change:.3%}]' if summary.hurdle > 0 else 'Unknown'
+
     return [
         f'{summary.timestamp.strftime("%Y-%m-%d %H:%M")}',
         '***' if summary.timestamp > thirty_ago else '---',
         f'{summary.leading_candidate_name} up {summary.vote_differential:,}',
-        f'Left (est.): {summary.votes_remaining:,}',
+        f'Left (est.): {summary.votes_remaining:,}' if summary.votes_remaining > 0 else 'Unknown',
         f'Δ: {summary.new_votes:7,} ({f"{bumped_name} +{bumped:5.01%}" if summary.leading_candidate_partition else "n/a"})',
         f'{summary.precincts_reporting/summary.precincts_total:.2%} precincts',
-        f'{summary.trailing_candidate_name} needs {summary.hurdle:.2%} [{summary.hurdle_change:.3%}]',
+        f'{visible_hurdle}',
         f'& trends  {f"{summary.hurdle_mov_avg:.2%}" if summary.hurdle_mov_avg else "n/a"}'
     ]
 
@@ -211,12 +213,13 @@ def html_write_state_head(state: str, state_slug: str, summary: IterationSummary
     '''
 
 def html_summary(state_slug: str, summary: IterationSummary):
+    shown_votes_remaining = f'{summary.votes_remaining:,}' if summary.votes_remaining > 0 else 'Unknown'
     html = f'''
         <tr id='{state_slug}-{summary.timestamp.isoformat()}'>
             <td class="timestamp">{summary.timestamp.strftime('%Y-%m-%d %H:%M:%S')} UTC</td>
             <td class="{summary.leading_candidate_name}">{summary.leading_candidate_name}</td>
             <td>{summary.vote_differential:,}</td>
-            <td>{summary.votes_remaining:,}</td>
+            <td>{shown_votes_remaining}</td>
             <td>{summary.new_votes:7,}</td>
     '''
 
@@ -238,9 +241,10 @@ def html_summary(state_slug: str, summary: IterationSummary):
         '''
     else:
         html += '<td>N/A</td>'
-
+    
+    visible_hurdle = f'{summary.trailing_candidate_name} needs {summary.hurdle:.2%} [{summary.hurdle_change:.3%}]' if summary.hurdle > 0 else 'Unknown'
     html += f'''
-            <td>{summary.trailing_candidate_name} needs {summary.hurdle:.2%} [{summary.hurdle_change:.3%}]</td>
+            <td>{visible_hurdle}</td>
         </tr>
     '''
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation

This PR tries to fix the issue https://github.com/alex/nyt-2020-election-scraper/issues/292 . When the data doesn't give us an accurate estime (e.g. the estimate is negative) we'll err on the side of Saying "Unknown" instead of showing a negative value.

![image](https://user-images.githubusercontent.com/14008484/98420693-b7a0a680-2055-11eb-9b25-87dad1368860.png)

Fixes #292

###### Changes

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
