### PR TITLE
Add Oxford comma to notifications

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -333,7 +333,25 @@
             }
 
             if (shouldNotify && Notification.permission === "granted") {
-                const notification = new Notification(`New ballots were counted in: ${latestMetadata.states_updated.join(", ")}!`);
+                const lastIndex = latestMetadata.states_updated.length - 1
+                const useCommas = latestMetadata.states_updated.length >= 3
+
+                const oxfordCommaList = stateList.reduce((accumulator, currentValue, index) => {
+                  switch (index) {
+                    case 0:
+                      return currentValue;
+                    case lastIndex:
+                      if (useCommas) {
+                        return `${accumulator}, and ${currentValue}`
+                      } else {
+                        return `${accumulator} and ${currentValue}`
+                      }
+                    default:
+                      return `${accumulator}, ${currentValue}`
+                  }
+                })
+
+                const notification = new Notification(`New ballots were counted in ${oxfordCommaList}!`);
                 notification.onclick = function (event) {
                     // focus page
                     window.parent.focus();


### PR DESCRIPTION
Problem: The notification looks like it's generated by a machine, which
is true, but I found the format slightly jarring.

Solution: Use an English representation of the list of states with an
Oxford comma.

Examples:

- Alabama
- Alabama and Alaska
- Alabama, Alaska, and Arizona
- Alabama, Alaska, Arizona, and Arkansas

---

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
