### PR TITLE
fix reparition == 0 issue

### DIFF
--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -181,7 +181,7 @@ def string_summary(summary):
         '***' if summary.timestamp > thirty_ago else '---',
         f'{summary.leading_candidate_name} up {summary.vote_differential:,}',
         f'Left (est.): {summary.votes_remaining:,}' if summary.votes_remaining > 0 else 'Unknown',
-        f'Δ: {summary.new_votes:7,} ({f"{bumped_name} +{bumped:5.01%}" if summary.leading_candidate_partition else "n/a"})',
+        f'Δ: {summary.new_votes:7,} ({f"{bumped_name} +{bumped:5.01%}" if (summary.leading_candidate_partition or summary.trailing_candidate_partition)  else "n/a"})',
         f'{summary.precincts_reporting/summary.precincts_total:.2%} precincts',
         f'{visible_hurdle}',
         f'& trends  {f"{summary.hurdle_mov_avg:.2%}" if summary.hurdle_mov_avg else "n/a"}'
@@ -223,7 +223,7 @@ def html_summary(state_slug: str, summary: IterationSummary):
             <td>{summary.new_votes:7,}</td>
     '''
 
-    if (summary.leading_candidate_partition):
+    if (summary.leading_candidate_partition or summary.trailing_candidate_partition):
         html += f'''
             <td>
                 {summary.leading_candidate_name} {summary.leading_candidate_partition:5.01%} /


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation

Fixes an issue where when the repartition was completely in favor of one candidate, the Block Breakdown will show N/A

Before:
![image](https://user-images.githubusercontent.com/14008484/98423996-5fba6d80-205e-11eb-917f-ea542e548079.png)

After:
![image](https://user-images.githubusercontent.com/14008484/98424008-63e68b00-205e-11eb-9f1d-882eb5d5f767.png)

Fixes https://github.com/alex/nyt-2020-election-scraper/issues/301

###### Changes

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
