### PR TITLE
Add scroll-top-margin to rows to fix sticky covering deep link

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -73,6 +73,11 @@
         border-right-width: 1px;
     }
 
+    tr {
+        /* Fixes position: sticky headers from covering rows when deep linked, by keeping the anchor away from the top */
+        scroll-margin-top: 130px;
+    }
+
     .has-tip {
         text-decoration: underline;
         text-decoration-style: dotted;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation
When deep linking to a specific batch via timestamp anchor, the row was being covered by the sticky table header, discussed in #242. This fixes that. 

###### Changes
This adds a style to rows that specifies there should be some margin from the top of the window when linked (only applies during [scroll snapping](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top)).

NOTE: I added more than required margin for normal desktop use cases to account for smaller windows, when the header takes up more height. I felt `130px` covered the "very small window" use case adequately without being obnoxious for the "normal" case.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.

## Before
(Wrong row is visible after clicking deep link)
![image](https://user-images.githubusercontent.com/455648/98429337-e79e7880-205a-11eb-89fb-d2db601d608c.png)

## After
(Correct row is visible after clicking deep link)
![image](https://user-images.githubusercontent.com/455648/98429389-1e748e80-205b-11eb-8e48-5ebbe19b1d5a.png)

