### PR TITLE
Generate Firefox and WebKit screenshots

### DIFF
--- a/.github/screenshot/index.js
+++ b/.github/screenshot/index.js
@@ -18,9 +18,22 @@ const HTML_URL = url.pathToFileURL(path.join(REPOSITORY_ROOT, "battleground-stat
 
     async function screenshot(filename) {
         await page.goto(HTML_URL, { waitUntil: "networkidle0" });
+
         await page.screenshot({
             path: path.join(REPOSITORY_ROOT, `screenshot-${filename}.png`),
             fullPage: true,
+        });
+
+        await page.evaluate(() => {
+            (() => {
+                const feature = features["shrunk"];
+                feature.onDisable($(feature.buttonId));
+
+                document.querySelector("#arizona tr:nth-last-child(5)").scrollIntoView(true);
+            })();
+        });
+        await page.screenshot({
+            path: path.join(REPOSITORY_ROOT, `screenshot-${filename}-scrolled.png`),
         });
     }
 

--- a/.github/screenshot/index.js
+++ b/.github/screenshot/index.js
@@ -1,5 +1,8 @@
+const finalhandler = require("finalhandler");
+const http = require("http");
 const path = require("path");
 const puppeteer = require("puppeteer");
+const serveStatic = require("serve-static");
 const url = require("url");
 
 const DEVICES = {
@@ -10,17 +13,53 @@ const DEVICES = {
 };
 
 const REPOSITORY_ROOT = path.resolve(__dirname, "../..");
-const HTML_URL = url.pathToFileURL(path.join(REPOSITORY_ROOT, "battleground-state-changes.html"));
+
+/* Exit on uncaught asynchronous exceptions to propagate the error to CI */
+process.on("unhandledRejection", (reason, promise) => {
+    console.error(reason);
+    process.exit(1);
+});
 
 (async function () {
+    /*
+     * Firefox's Puppeteer implementation doesn't play well with file:// URLs,
+     * see https://github.com/puppeteer/puppeteer/issues/5504.
+     *
+     * As a workaround, run an HTTP server. :(
+     */
+    const serve = serveStatic(REPOSITORY_ROOT);
+    const server = http.createServer((request, response) => {
+        /* https://expressjs.com/en/resources/middleware/serve-static.html#serve-files-with-vanilla-nodejs-http-server */
+        serve(request, response, finalhandler(request, response));
+    });
+    server.listen();
+
+    const address = server.address();
+    const pageUrl = url.format({
+        protocol: "http",
+        hostname: address.address,
+        port: address.port,
+        pathname: "battleground-state-changes.html",
+    });
+    console.log(`Server listening at ${pageUrl}`);
+
+    /*
+     * Puppeteer refuses to install Chromium and Firefox at the same time, so
+     * we have to use PUPPETEER_PRODUCT to choose which browser to install and
+     * use. Sigh.
+     */
+    const product = puppeteer.product;
+    console.log(`Launching ${product}`);
+
     const browser = await puppeteer.launch();
     const page = await browser.newPage();
 
     async function screenshot(filename) {
-        await page.goto(HTML_URL, { waitUntil: "networkidle0" });
+        console.log(`Generating ${filename}`);
+        await page.goto(pageUrl, { waitUntil: "load" });
 
         await page.screenshot({
-            path: path.join(REPOSITORY_ROOT, `screenshot-${filename}.png`),
+            path: path.join(REPOSITORY_ROOT, `screenshot-${product}-${filename}.png`),
             fullPage: true,
         });
 
@@ -33,13 +72,13 @@ const HTML_URL = url.pathToFileURL(path.join(REPOSITORY_ROOT, "battleground-stat
             })();
         });
         await page.screenshot({
-            path: path.join(REPOSITORY_ROOT, `screenshot-${filename}-scrolled.png`),
+            path: path.join(REPOSITORY_ROOT, `screenshot-${product}-${filename}-scrolled.png`),
         });
     }
 
     await page.setViewport({
-        width: 1920,
-        height: 1080,
+        width: 1280,
+        height: 720,
     });
     await screenshot("desktop");
 
@@ -49,4 +88,5 @@ const HTML_URL = url.pathToFileURL(path.join(REPOSITORY_ROOT, "battleground-stat
     }
 
     await browser.close();
+    server.close();
 })();

--- a/.github/screenshot/package-lock.json
+++ b/.github/screenshot/package-lock.json
@@ -83,10 +83,30 @@
         "ms": "2.1.2"
       }
     },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
     "devtools-protocol": {
       "version": "0.0.809251",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.809251.tgz",
       "integrity": "sha512-pf+2OY6ghMDPjKkzSWxHMq+McD+9Ojmq5XVRYpv/kPd9sTMQxzEt21592a31API8qRjro0iYYOc3ag46qF/1FA=="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -95,6 +115,16 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "extract-zip": {
       "version": "2.0.1",
@@ -115,6 +145,35 @@
         "pend": "~1.2.0"
       }
     },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -123,6 +182,11 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -153,6 +217,18 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "http-errors": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
       }
     },
     "https-proxy-agent": {
@@ -191,6 +267,11 @@
         "p-locate": "^4.1.0"
       }
     },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -213,6 +294,14 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -242,6 +331,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "path-exists": {
       "version": "4.0.0",
@@ -304,6 +398,11 @@
         "ws": "^7.2.3"
       }
     },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
     "readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -326,6 +425,69 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -363,6 +525,11 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
     "unbzip2-stream": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
@@ -371,6 +538,11 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/.github/screenshot/package-lock.json
+++ b/.github/screenshot/package-lock.json
@@ -219,6 +219,11 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+    },
     "http-errors": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
@@ -258,6 +263,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "jpeg-js": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
+      "integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw=="
     },
     "locate-path": {
       "version": "5.0.0",
@@ -360,10 +370,67 @@
         "find-up": "^4.0.0"
       }
     },
+    "playwright-webkit": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/playwright-webkit/-/playwright-webkit-1.5.2.tgz",
+      "integrity": "sha512-E8bMYxueeOe+r/Gb+/zAcJRrf+uUb32f3b6iU5IZxi/T+qVUpO63uk9Yz69x/IC9MLo6n7/4bLk3kVyogRatfA==",
+      "requires": {
+        "debug": "^4.1.1",
+        "extract-zip": "^2.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "jpeg-js": "^0.4.2",
+        "mime": "^2.4.6",
+        "pngjs": "^5.0.0",
+        "progress": "^2.0.3",
+        "proper-lockfile": "^4.1.1",
+        "proxy-from-env": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "ws": "^7.3.1"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "mime": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+        }
+      }
+    },
+    "pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+    },
+    "proper-lockfile": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.1.tgz",
+      "integrity": "sha512-1w6rxXodisVpn7QYvLk706mzprPTAPCYAqxMvctmPN3ekuRk/kuGkGc82pangZiAt4R3lwSuUzheTTn0/Yb7Zg==",
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
     },
     "proxy-from-env": {
       "version": "1.1.0",
@@ -412,6 +479,11 @@
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
       }
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -483,6 +555,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "statuses": {
       "version": "1.5.0",

--- a/.github/screenshot/package.json
+++ b/.github/screenshot/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "finalhandler": "^1.1.2",
+    "playwright-webkit": "^1.5.2",
     "puppeteer": "^5.4.1",
     "serve-static": "^1.14.1"
   },

--- a/.github/screenshot/package.json
+++ b/.github/screenshot/package.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
-    "puppeteer": "^5.4.1"
+    "finalhandler": "^1.1.2",
+    "puppeteer": "^5.4.1",
+    "serve-static": "^1.14.1"
   },
   "scripts": {
     "start": "node index.js"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,8 +45,10 @@ jobs:
 
     - name: Generate screenshots
       run: |-
-        npm install --prefix .github/screenshot
-        npm start --prefix .github/screenshot
+        PUPPETEER_PRODUCT=chrome npm install --prefix .github/screenshot
+        PUPPETEER_PRODUCT=chrome npm start --prefix .github/screenshot
+        PUPPETEER_PRODUCT=firefox npm install --prefix .github/screenshot puppeteer
+        PUPPETEER_PRODUCT=firefox npm start --prefix .github/screenshot
     - name: Upload screenshots
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,8 +45,11 @@ jobs:
 
     - name: Generate screenshots
       run: |-
-        PUPPETEER_PRODUCT=chrome npm install --prefix .github/screenshot
-        PUPPETEER_PRODUCT=chrome npm start --prefix .github/screenshot
+        sudo apt-get install libwebkit2gtk-4.0-37 libgles2 gstreamer1.0-libav libgstreamer-plugins-bad1.0-0 xvfb
+        npm install --prefix .github/screenshot
+        npm start --prefix .github/screenshot
+        # WebKit doesn't work properly in headless mode, use an Xvfb server
+        PUPPETEER_PRODUCT=webkit xvfb-run npm start --prefix .github/screenshot
         PUPPETEER_PRODUCT=firefox npm install --prefix .github/screenshot puppeteer
         PUPPETEER_PRODUCT=firefox npm start --prefix .github/screenshot
     - name: Upload screenshots


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation

We have lots of Firefox and Safari users, so we should also generate screenshots for those browsers to ensure the site looks correct. Instead of using a macOS system, a recent build of WebKit on Linux should be a sufficient approximation of Safari.

###### Changes

Microsoft's [Playwright](https://github.com/microsoft/playwright) looked like the easy path to victory to get support across the full gamut of browsers, but it was a disaster in every way (e.g., screenshots from Chromium were clear regressions from Puppeteer, it would try to use unsupported Firefox features and throw an error, the shipped WebKit build had various linking issues).

Instead, use Puppeteer's experimental Firefox support which, while creating a lot of complications (e.g. having to spin up an HTTP server since it doesn't play well with `file://` URLs, and having to run `npm install` twice) seems to work sufficiently well.

For WebKit support, I initially tried `wkhtmltoimage` but it doesn't play well with any kind of modern JavaScript. In the end, I wrote shims to abstract away the API differences so we could use Puppeteer for Chromium and Firefox, and Playwright for WebKit.

Notably, despite claiming to have headless support, the WebKit build shipped with Playwright seems to hang in certain configurations. The simplest solution is to use the Xvfb server and run in headful mode.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
