### PR TITLE
add margin percentage to vote margin column

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -99,6 +99,11 @@
         background-color: #ED98A9;
     }
 
+
+    .margin{
+        opacity: 0.7;
+    }
+
     @media (prefers-color-scheme: dark) {
         body {
             color: #ffffff;

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -214,11 +214,12 @@ def html_write_state_head(state: str, state_slug: str, summary: IterationSummary
 
 def html_summary(state_slug: str, summary: IterationSummary):
     shown_votes_remaining = f'{summary.votes_remaining:,}' if summary.votes_remaining > 0 else 'Unknown'
+    margin_percent = (summary.leading_candidate_votes-summary.trailing_candidate_votes)/(summary.leading_candidate_votes+summary.trailing_candidate_votes)
     html = f'''
         <tr id='{state_slug}-{summary.timestamp.isoformat()}'>
             <td class="timestamp">{summary.timestamp.strftime('%Y-%m-%d %H:%M:%S')} UTC</td>
             <td class="{summary.leading_candidate_name}">{summary.leading_candidate_name}</td>
-            <td>{summary.vote_differential:,}</td>
+            <td>{summary.vote_differential:,} <span class="margin">({margin_percent:3.2%})</span></td>
             <td>{shown_votes_remaining}</td>
             <td>{summary.new_votes:7,}</td>
     '''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation

I like the idea in #287 but wanted to suggest adding the percentage to the vote margin column instead, so it can be displayed along with the raw numbers.  Also reduced the opacity so it's a little easier to read.  Feel free to close if you like the other approach better!

screenshot

![Capture](https://user-images.githubusercontent.com/287961/98436425-117e8c00-20a9-11eb-9a82-0b6c8ab43245.PNG)



###### Changes

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [ ] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
