### PR TITLE
Move state flag to the left in the header

### DIFF
--- a/battleground-state-changes.html
+++ b/battleground-state-changes.html
@@ -45,6 +45,11 @@
 
     thead .text-left {
         font-weight: normal;
+        background-position: left;
+        padding-left: 138px;
+        padding-top: 10px;
+        padding-bottom: 10px;
+        line-height: 25px;
     }
 
     thead span.statename {


### PR DESCRIPTION
Move state flag to left and space out table title for enhanced readability

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation
Anchor the state awareness visually beyond reading the state name.
Enhance reader's awareness of each state flag.

###### Changes
Move background image to left of header
Add padding to offset the title text.
Increase line-height slightly to separate title from description.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [ ] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [ ] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [ ] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
