### PR TITLE
Change colors to be more colorblind-friendly.

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -93,10 +93,10 @@
     }
 
     .Biden{
-        background-color: #84C4EE
+        background-color: #b2aad1;
     }
     .Trump{
-        background-color: #ED98A9;
+        background-color: #fcb762;
     }
 
     .table td.batch-cell {
@@ -127,10 +127,10 @@
             border-color: #211d19;
         }
         .Biden {
-            background-color: #05456F;
+            background-color: #5e3b98;
         }
         .Trump {
-            background-color: #6E192A;
+            background-color: #e66001;
         }
     }
     </style>


### PR DESCRIPTION
Colors taken from https://knightlab.northwestern.edu/2016/07/18/three-tools-to-help-you-make-colorblind-friendly-graphics/

------

<img width="1280" alt="Screen Shot 2020-11-07 at 10 43 21 AM" src="https://user-images.githubusercontent.com/416575/98445674-ddc25700-20e6-11eb-935b-b633d7380b63.png">

------

<img width="1277" alt="Screen Shot 2020-11-07 at 10 47 59 AM" src="https://user-images.githubusercontent.com/416575/98445677-e0bd4780-20e6-11eb-91e7-c4493c6517b9.png">
