### PR TITLE
Matches Hurdle's precision to the other percentages

### DIFF
--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -242,7 +242,7 @@ def html_summary(state_slug: str, summary: IterationSummary):
     else:
         html += '<td>N/A</td>'
     
-    visible_hurdle = f'{summary.trailing_candidate_name} needs {summary.hurdle:.2%}' if summary.hurdle > 0 else 'Unknown'
+    visible_hurdle = f'{summary.trailing_candidate_name} needs {summary.hurdle:.1%}' if summary.hurdle > 0 else 'Unknown'
     html += f'''
             <td class="hurdle">{visible_hurdle}</td>
         </tr>


### PR DESCRIPTION
##### Motivation

Fixes #327

###### Changes

Drops the printed precision on hurdle from 2 sigfigs to 1 to match the Trend & other percentages

From:
![image](https://user-images.githubusercontent.com/681004/98447181-c1c3b300-20f0-11eb-9500-f18cf40dc2e7.png)

To:
![image](https://user-images.githubusercontent.com/681004/98447031-d3f12180-20ef-11eb-9655-fbc9885ab119.png)


- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
