### PR TITLE
feat: add improved breakdown as graphical

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -99,6 +99,18 @@
         background-color: #ED98A9;
     }
 
+    .table td.batch-cell {
+        display: flex;
+        padding: 0;
+    }
+
+    .batch-breakdown {
+        flex: 0 1 auto;
+        overflow: hidden;
+        padding: .25rem .5rem;
+        text-overflow: ellipsis;
+    }
+
     @media (prefers-color-scheme: dark) {
         body {
             color: #ffffff;

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -225,9 +225,9 @@ def html_summary(state_slug: str, summary: IterationSummary):
 
     if (summary.leading_candidate_partition or summary.trailing_candidate_partition):
         html += f'''
-            <td>
-                {summary.leading_candidate_name} {summary.leading_candidate_partition:5.01%} /
-                {summary.trailing_candidate_partition:5.01%} {summary.trailing_candidate_name}
+            <td class="batch-cell">
+                <div class="batch-breakdown {summary.leading_candidate_name}" style="width: {summary.leading_candidate_partition:5.01%}" title="{summary.leading_candidate_name} {summary.leading_candidate_partition:5.01%}">{summary.leading_candidate_partition:5.01%}</div>
+                <div class="batch-breakdown {summary.trailing_candidate_name}" style="width: {summary.trailing_candidate_partition:5.01%}" title="{summary.trailing_candidate_name} {summary.trailing_candidate_partition:5.01%}">{summary.trailing_candidate_partition:5.01%}</div>
             </td>
         '''
     else:


### PR DESCRIPTION
- use `hidden` instead of `clip` on `overflow`
- add in handling for ellipsis

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation

###### Changes

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [ ] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.

Screenshot (Chrome, Safari, firefox latest): 
![Screen Shot 2020-11-07 at 09 38 14 ](https://user-images.githubusercontent.com/3056447/98447920-79e76080-20dd-11eb-9a7c-2a00ebd66291.png)
