### PR TITLE
Add estimated county-level breakdown

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -195,7 +195,7 @@
         <div class="col-sm">
             <p style="font-size: 1.4rem;">
                 All data below is sourced from an unofficial API powering the New York Times’ election site.
-                <strong>The estimated votes remaining values might be off</strong>.
+                <strong>The estimated votes remaining and county-level breakdown values might be off</strong>.
                 Consult state websites and officials for the most accurate and up-to-date figures.
                 This website is <a href="https://github.com/alex/nyt-2020-election-scraper">open source</a> and was written by <a href="https://github.com/alex/nyt-2020-election-scraper/graphs/contributors">these people</a>.
             </p>
@@ -269,6 +269,7 @@
     <script type="text/javascript">
         const loadTooltips = () => {
             $(function () {
+                $('[data-title]').removeAttr('title');
                 $('[data-toggle="tooltip"]').tooltip({ boundary: 'window' })
             })
         };

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -70,6 +70,7 @@ def fetch_all_records():
                 sum(map(lambda n: n['tot_exp_vote'], race['counties'])),
                 race['precincts_total'],
                 race['precincts_reporting'],
+                {n['name']: n['votes'] for n in race['counties']},
                 )
             rows.append(record)
             out.append(record)
@@ -98,13 +99,14 @@ InputRecord = collections.namedtuple(
         'expected_votes',
         'precincts_total',
         'precincts_reporting',
+        'counties',
     ],
 )
 
 # Information that is shared across loop iterations
 IterationInfo = collections.namedtuple(
     'IterationInfo',
-    ['vote_diff', 'votes', 'precincts_reporting', 'hurdle', 'leading_candidate_name']
+    ['vote_diff', 'votes', 'precincts_reporting', 'hurdle', 'leading_candidate_name', 'counties']
 )
 
 IterationSummary = collections.namedtuple(
@@ -124,7 +126,8 @@ IterationSummary = collections.namedtuple(
         'precincts_total',
         'hurdle',
         'hurdle_change',
-        'hurdle_mov_avg'
+        'hurdle_mov_avg',
+        'counties_partition',
     ]
 )
 
@@ -204,7 +207,7 @@ def html_write_state_head(state: str, state_slug: str, summary: IterationSummary
             <th class="has-tip" data-toggle="tooltip" title="Which candidate currently leads this state?">In The Lead</th>
             <th class="has-tip" data-toggle="tooltip" title="How many votes separate the two candidates?">Vote Margin</th>
             <th class="has-tip" data-toggle="tooltip" title="Approximately how many votes are remaining to be counted? These values might be off! Consult state websites and officials for the most accurate and up-to-date figures.">Votes Remaining (est.)</th>
-            <th class="has-tip" data-toggle="tooltip" title="How many votes were reported in this batch?">Change</th>
+            <th class="has-tip" data-toggle="tooltip" title="How many votes were reported in this batch? If available, an estimated county-level breakdown is shown, but it might be inaccurate!">Change</th>
             <th class="has-tip" data-toggle="tooltip" title="How did the votes in this batch break down, per candidate. Based on the number of reported votes and the change in margin.">Batch Breakdown</th>
             <th class="has-tip" data-toggle="tooltip" title="How has the trailing candidate's share of recent batches trended? Computed using a moving average of previous 30k votes.">Batch Trend</th>
             <th class="has-tip" data-toggle="tooltip" title="What percentage of the remaining votes does the trailing candidate need to flip the lead. 'Flip' happens at 50%, not at 0%. Note that third party candidates are not included in the batch breakdown! This is intentional.">Hurdle</th>
@@ -213,6 +216,20 @@ def html_write_state_head(state: str, state_slug: str, summary: IterationSummary
     '''
 
 def html_summary(state_slug: str, summary: IterationSummary):
+    if summary.counties_partition:
+        counties_partition = sorted(summary.counties_partition.items(), key=lambda x: x[1], reverse=True)
+        counties_total = sum(summary.counties_partition.values())
+        counties_tooltip_attributes = (
+            'class="has-tip" data-toggle="tooltip" data-html="true" data-title="' +
+            '<strong>Estimated county-level breakdown:</strong><br>' +
+            '<br>'.join(f'<strong>{name}:</strong> {value / counties_total:.2%}' for name, value in counties_partition) +
+            '" title="' +
+            'Estimated county-level breakdown: ' +
+            ', '.join(f'{name}: {value / counties_total:.2%}' for name, value in counties_partition) +
+            '"'
+        )
+    else:
+        counties_tooltip_attributes = ''
     shown_votes_remaining = f'{summary.votes_remaining:,}' if summary.votes_remaining > 0 else 'Unknown'
     html = f'''
         <tr id='{state_slug}-{summary.timestamp.isoformat()}'>
@@ -220,7 +237,7 @@ def html_summary(state_slug: str, summary: IterationSummary):
             <td class="{summary.leading_candidate_name}">{summary.leading_candidate_name}</td>
             <td>{summary.vote_differential:,}</td>
             <td>{shown_votes_remaining}</td>
-            <td>{summary.new_votes:7,}</td>
+            <td {counties_tooltip_attributes}>{summary.new_votes:7,}</td>
     '''
 
     if (summary.leading_candidate_partition or summary.trailing_candidate_partition):
@@ -282,6 +299,14 @@ def json_to_summary(
     precincts_total = row.precincts_total
     new_votes = 0 if last_iteration_info.votes is None else (votes - last_iteration_info.votes)
 
+    counties_partition = {}
+    if new_votes != 0:
+        assert row.counties.keys() == last_iteration_info.counties.keys()
+        for k, v in row.counties.items():
+            partition = (v - last_iteration_info.counties[k])
+            if partition > 0:
+                counties_partition[k] = partition
+
     bumped = candidate1_name != last_iteration_info.leading_candidate_name
 
     hurdle = (vote_diff + (votes_remaining * (candidate1_votes + candidate2_votes)) / votes) / (2 * votes_remaining) if votes_remaining > 0 else 0
@@ -296,7 +321,8 @@ def json_to_summary(
         votes=votes,
         precincts_reporting=precincts_reporting,
         hurdle=hurdle,
-        leading_candidate_name=candidate1_name
+        leading_candidate_name=candidate1_name,
+        counties=row.counties,
     )
 
     # Compute aggregate of last 5 hurdle, if available
@@ -317,7 +343,8 @@ def json_to_summary(
         precincts_total,
         hurdle,
         hurdle-(1-last_iteration_info.hurdle if bumped else last_iteration_info.hurdle),
-        hurdle_mov_avg
+        hurdle_mov_avg,
+        counties_partition,
     )
 
     return iteration_info, summary
@@ -335,7 +362,8 @@ for rows in records.values():
         votes=None,
         precincts_reporting=None,
         hurdle=0,
-        leading_candidate_name=None
+        leading_candidate_name=None,
+        counties=None,
     )
 
     for row in rows:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation

Being able to see county-level breakdown is useful. This has been requested in #307, #308, and #310.

The NYT's county-level data does not correspond exactly to its state-level data. If you sum the county-level votes, you'll frequently obtain a different number to the state-level votes, either larger or smaller.

###### Changes

1. Load county-level votes data from the JSON by adding a `counties` dict to the `InputRecord`
2. Add only increases (yes, the number sometimes goes down!) in county votes to a `counties_partition` dict in the `IterationSummary`
3. Add a tooltip with the increase in each county's votes displayed as a percentage of the total change in county votes.

Since the tooltip uses HTML, I've used `data-title` for the HTML version and `title` for a plaintext version (so users without JavaScript can still make use of this feature). To ensure that `data-title` takes precedence, the `title` attribute is removed with JavaScript before the tooltips are instantiated.

New `Change` tooltip:

![](https://user-images.githubusercontent.com/22301423/98448258-b8ebd500-2122-11eb-82bb-e046524bc9bd.png)

With JavaScript:

![](https://user-images.githubusercontent.com/22301423/98448245-9d80ca00-2122-11eb-92aa-ea0041c21fe4.png)

Without JavaScript:

![](https://user-images.githubusercontent.com/22301423/98448208-54c91100-2122-11eb-8e63-e55de94946b1.png)

###### Concerns

- I'm no expert, but I imagine it's difficult for assistive-technology users to view this data because it uses a tooltip but the table cells aren't focusable

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
