### PR TITLE
Use 0 decimal places for county-level breakdown

### DIFF
--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -222,10 +222,10 @@ def html_summary(state_slug: str, summary: IterationSummary):
         counties_tooltip_attributes = (
             'class="has-tip" data-toggle="tooltip" data-html="true" data-title="' +
             '<strong>Estimated county-level breakdown:</strong><br>' +
-            '<br>'.join(f'<strong>{name}:</strong> {value / counties_total:.2%}' for name, value in counties_partition) +
+            '<br>'.join(f'<strong>{name}:</strong> {value / counties_total:.0%}' for name, value in counties_partition) +
             '" title="' +
             'Estimated county-level breakdown: ' +
-            ', '.join(f'{name}: {value / counties_total:.2%}' for name, value in counties_partition) +
+            ', '.join(f'{name}: {value / counties_total:.0%}' for name, value in counties_partition) +
             '"'
         )
     else:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation

2 decimal places for the county-level breakdowns is excessive and visually noisy.

###### Changes

Use 0 decimal places instead.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [ ] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
