### PR TITLE
Don't notify if the state isn't in the battleground list

### DIFF
--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -428,6 +428,10 @@ battlegrounds_summarized = {
     for state, results in summarized.items()
     if state in BATTLEGROUND_STATES
 }
+states_updated = [
+    state for state in states_updated
+    if any(state in bs for bs in BATTLEGROUND_STATES)
+]
 
 # print the summaries
 batch_time = max(itertools.chain.from_iterable(summarized.values()), key=lambda s: s.timestamp).timestamp


### PR DESCRIPTION
###### Motivation

Bad notifications are bad

###### Changes

Filter down the list of updated states to not include ones not in the battleground states list

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
