### PR TITLE
Fix batch time to match battleground states again

### DIFF
--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -436,7 +436,7 @@ states_updated = [
 ]
 
 # print the summaries
-batch_time = max(itertools.chain.from_iterable(summarized.values()), key=lambda s: s.timestamp).timestamp
+batch_time = max(itertools.chain.from_iterable(battlegrounds_summarized.values()), key=lambda s: s.timestamp).timestamp
 with open("results.json", "r", encoding='utf8') as f:
     RESULTS_HASH = hashlib.sha256(f.read().encode('utf8')).hexdigest()
 


### PR DESCRIPTION
###### Motivation

The batch time is wrong now :( It is pulling the timestamp from the latest batch across all states, not just the battlegrounds.

<img src="https://user-images.githubusercontent.com/681004/98456151-f0b94380-2147-11eb-96bb-dfc0bbae5d05.png"  height="500">



###### Changes

Use the right summary for calculating the last batch time

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
