### PR TITLE
Changes to hurdle calculation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 **Describe the bug**
 
-Please make sure you're not reporting that the hurdle calculation is incorrect! Please see https://github.com/alex/nyt-2020-election-scraper/issues/194; the block breakdown does not match the hurdle rate because we're not tracking third party candidates. We don't have plans to change this.
+Please make sure you're not reporting that the hurdle calculation is incorrect! Please see https://github.com/alex/nyt-2020-election-scraper/pull/367; the block breakdown might not match the hurdle because of the way third-party candidates affect the calculations. We don't have plans to change this.
 
 **To Reproduce**
 Steps to reproduce the behavior:

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -227,7 +227,7 @@ def html_write_state_head(state: str, state_slug: str, summary: IterationSummary
             <th class="has-tip numeric" data-toggle="tooltip" title="How many votes were reported in this batch? This includes third-party votes. If available, an estimated county-level breakdown is shown, but it might be inaccurate!">Change</th>
             <th class="has-tip" data-toggle="tooltip" title="How were the votes in this batch, excluding third-party votes, split between the two candidates?">Batch Breakdown</th>
             <th class="has-tip" data-toggle="tooltip" title="How has the trailing candidate's share of recent batches trended? Computed using a moving average of previous 30k votes.">Batch Trend</th>
-            <th class="has-tip" data-toggle="tooltip" title="What percentage of the remaining votes does the trailing candidate need to flip the lead. 'Flip' happens at 50%, not at 0%. Note that third party candidates are not included in the batch breakdown! This is intentional.">Hurdle</th>
+            <th class="has-tip" data-toggle="tooltip" title="What percentage of estimated remaining votes (excluding third-party votes) does the trailing candidate need to take the lead? Since this assumes the proportion of third-party votes remains the same, this might deviate from the breakdown in batches where this is not the case.">Hurdle</th>
         </tr>
         </thead>
     '''
@@ -330,7 +330,8 @@ def json_to_summary(
 
     bumped = candidate1_name != last_iteration_info.leading_candidate_name
 
-    hurdle = (vote_diff + (votes_remaining * (candidate1_votes + candidate2_votes)) / votes) / (2 * votes_remaining) if votes_remaining > 0 else 0
+    votes_remaining_relevant = votes_remaining * (candidate1_votes + candidate2_votes) / votes
+    hurdle = (vote_diff + votes_remaining_relevant) / (2 * votes_remaining_relevant) if votes_remaining_relevant > 0 else 0
 
     candidate_votes = {c['candidate_key']: c['votes'] for c in row.candidates}
 

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -13,7 +13,7 @@ import subprocess
 import json
 from textwrap import dedent, indent
 from tabulate import tabulate
-from typing import Tuple
+from typing import Dict, Tuple
 
 AK_INDEX = 0
 AZ_INDEX = 3
@@ -298,6 +298,7 @@ def json_to_summary(
     state_name: str,
     row: InputRecord,
     last_iteration_info: IterationInfo,
+    latest_candidate_votes: Dict[str, int],
     batch_time: datetime.datetime,
 ) -> Tuple[IterationInfo, IterationSummary]:
     timestamp = datetime.datetime.strptime(row.timestamp, '%Y-%m-%dT%H:%M:%S.%fZ')
@@ -330,7 +331,11 @@ def json_to_summary(
 
     bumped = candidate1_name != last_iteration_info.leading_candidate_name
 
-    votes_remaining_relevant = votes_remaining * (candidate1_votes + candidate2_votes) / votes
+    # If we're trying to estimate the proportion of third-party votes across
+    # the entire vote population, we want to use the largest sample size we
+    # have - i.e. the newest data we've received
+    latest_relevant_proportion = (latest_candidate_votes[candidate1_key] + latest_candidate_votes[candidate2_key]) / sum(latest_candidate_votes.values())
+    votes_remaining_relevant = votes_remaining * latest_relevant_proportion
     hurdle = (vote_diff + votes_remaining_relevant) / (2 * votes_remaining_relevant) if votes_remaining_relevant > 0 else 0
 
     candidate_votes = {c['candidate_key']: c['votes'] for c in row.candidates}
@@ -406,11 +411,14 @@ for rows in records.values():
         candidate_votes=None,
     )
 
+    latest_candidate_votes = {c['candidate_key']: c['votes'] for c in rows[-1].candidates}
+
     for row in rows:
         iteration_info, summary = json_to_summary(
             state_name,
             row,
             last_iteration_info,
+            latest_candidate_votes,
             batch_time=datetime.datetime.strptime(row.timestamp, '%Y-%m-%dT%H:%M:%S.%fZ'),
         )
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation

The hurdle calculation tries to take third-party votes into account. This was first raised in #194, and was implemented in #200.

However, it calculates the number of votes required for the hurdle using only "relevant" remaining votes (i.e. excluding third-party votes). But it then confusingly divides this by total remaining votes (i.e. including third-party votes).

This effectively makes the metric "what percentage of the remaining votes does the trailing candidate need, _assuming the other votes are divided up between the leading candidate and the third-party candidates_" which is unexpected and misleading (it makes it look like the trailing candidate has a lower hurdle to clear than they actually do).

A less confusing method is to simply divide by "relevant" remaining votes (i.e. excluding the third-party votes) instead of by total remaining votes. This still takes into account the third-party votes (i.e. "since some remaining votes will be third-party, the trailing candidate needs a higher percentage of future votes to close the gap than if there were no third-party") but gives a more expected hurdle percentage.

Note that this still doesn't fully fix the confusion when comparing to the batch breakdown (since a given batch will include more or less third-party votes than on average), but that's not really possible for us to fix with the data we have.

###### Changes

The first commit implements the change to the hurdle calculation described above, and also amends the hurdle tooltip to more explicitly explain how the calculation works.

The second commit adjusts the way the proportion of third-party votes is calculated. As the commit message states, we should use the latest data for calculating that proportion (due to Law of Large Numbers), though for our current data:

> In practice, this change makes a minute difference. The largest change for the current data was a 0.276 percentage point difference in the proportion of third-party votes, and a ~0.1 percentage point difference in calculated hurdle.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
