### PR TITLE
Use CSS for table shrink/expand

### DIFF
--- a/battleground-state-changes.html.tmpl
+++ b/battleground-state-changes.html.tmpl
@@ -38,6 +38,10 @@
         padding: .25rem .5rem;
     }
 
+    .table.shrunk tbody tr:not(.always-visible) {
+        display: none;
+    }
+
     thead td {
       background-color: #e9ecef;
       line-height: 1.2rem;
@@ -283,22 +287,10 @@
         const shrinkTablesFeature = 'shrunk';
         feature(shrinkTablesFeature, '#shrink_button', true, button => {
             button.html('Expand Tables');
-            $('.table').each(function(){
-                var countOfNonHiddenBlock = 0;
-                var lastCount = -1;
-                $(this).find('tbody tr').each(function() {
-                    var value = parseInt(($(this).find('td:nth(4)').text()));
-                    if (countOfNonHiddenBlock >= 3 || (value === 0 && lastCount === 0)) {
-                        $(this).hide();
-                    } else {
-                        countOfNonHiddenBlock++;
-                    }
-                    lastCount = value;
-                });
-            });
+            $('.table').addClass('shrunk');
         }, button => {
             button.html('Shrink Tables');
-            $('.table').each(function() { $(this).find('tbody tr').show(); });
+            $('.table').removeClass('shrunk');
         });
     </script>
 

--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -233,7 +233,7 @@ def html_write_state_head(state: str, state_slug: str, summary: IterationSummary
         </thead>
     '''
 
-def html_summary(state_slug: str, summary: IterationSummary):
+def html_summary(state_slug: str, summary: IterationSummary, always_visible: bool):
     if summary.counties_partition:
         counties_partition = sorted(summary.counties_partition.items(), key=lambda x: x[1], reverse=True)
         counties_total = sum(summary.counties_partition.values())
@@ -249,8 +249,9 @@ def html_summary(state_slug: str, summary: IterationSummary):
     else:
         counties_tooltip_attributes = 'class="numeric"'
     shown_votes_remaining = f'{summary.votes_remaining:,}' if summary.votes_remaining > 0 else 'Unknown'
+    always_visible_attribute = ' class="always-visible"' if always_visible else ''
     html = f'''
-        <tr id='{state_slug}-{summary.timestamp.isoformat()}'>
+        <tr id="{state_slug}-{summary.timestamp.isoformat()}"{always_visible_attribute}>
             <td class="timestamp">{summary.timestamp.strftime('%Y-%m-%d %H:%M:%S')} UTC</td>
             <td class="{summary.leading_candidate_name}">{summary.leading_candidate_name}</td>
             <td class="numeric">{summary.vote_differential:,}</td>
@@ -480,8 +481,20 @@ def html_table(summarized):
         state_slug = state.split('(')[0].strip().replace(' ', '-').lower()
         yield f"<div class='table-responsive'><table id='{state_slug}' class='table table-bordered'>"
         yield html_write_state_head(state, state_slug, timestamped_results[0])
+        visible_rows = 0
+        last_change_value = None
         for summary in timestamped_results:
-            yield html_summary(state_slug=state_slug, summary=summary)
+            change_value = summary.new_votes_formatted.strip()
+            if visible_rows >= 3:
+                always_visible = False
+            elif {change_value, last_change_value} <= {'0', 'Unknown'}:
+                always_visible = False
+            else:
+                always_visible = True
+                visible_rows += 1
+
+            yield html_summary(state_slug=state_slug, summary=summary, always_visible=always_visible)
+            last_change_value = change_value
         yield "</table></div><hr>"
 
 def html_output(path, html_table, states_updated, other_page_html):


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation

Currently, the shrink/expand table button is implemented in JavaScript, but it's slow because it has to iterate over each row.

###### Changes

Add an `always-visible` class to specific rows when generating the HTML, then use JavaScript to add/remove a CSS class `shrunk` when the `Shrink Tables`/`Expand Tables` button is clicked. This should be much faster.

/cc @JulesDT 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
