### PR TITLE
Always use latest expected votes value

### DIFF
--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -307,6 +307,7 @@ def json_to_summary(
     row: InputRecord,
     last_iteration_info: IterationInfo,
     latest_candidate_votes: Dict[str, int],
+    expected_votes: int,
     batch_time: datetime.datetime,
 ) -> Tuple[IterationInfo, IterationSummary]:
     timestamp = datetime.datetime.strptime(row.timestamp, '%Y-%m-%dT%H:%M:%S.%fZ')
@@ -323,7 +324,6 @@ def json_to_summary(
     total_votes = sum([candidate['votes'] for candidate in row.candidates])
     vote_diff = candidate1_votes - candidate2_votes
     votes = row.votes
-    expected_votes = row.expected_votes
     votes_remaining = expected_votes - votes
     precincts_reporting = row.precincts_reporting
     precincts_total = row.precincts_total
@@ -421,6 +421,7 @@ for rows in records.values():
     )
 
     latest_candidate_votes = {c['candidate_key']: c['votes'] for c in rows[-1].candidates}
+    latest_expected_votes = rows[-1].expected_votes
 
     for row in rows:
         iteration_info, summary = json_to_summary(
@@ -428,6 +429,7 @@ for rows in records.values():
             row,
             last_iteration_info,
             latest_candidate_votes,
+            latest_expected_votes,
             batch_time=datetime.datetime.strptime(row.timestamp, '%Y-%m-%dT%H:%M:%S.%fZ'),
         )
 


### PR DESCRIPTION
The latest batch contains the best estimate for the total expected votes
so we should always use it, even for old batches.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation

Similarly to how we use the latest proportion of third-party votes, as implemented in #367, we should use the latest expected votes value (since the latest estimate is the best estimate we have).

###### Changes

**Before:**

![](https://user-images.githubusercontent.com/22301423/98622243-f3ab6400-2300-11eb-990a-0bcc4eafb872.png)

**After:**

![](https://user-images.githubusercontent.com/22301423/98622113-a3cc9d00-2300-11eb-9789-b1fc9d12a4ee.png)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
