### PR TITLE
Use state abbreviations for notifications

### DIFF
--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -27,7 +27,7 @@ STATE_INDEXES = range(51) # 50 States + DC
 
 CACHE_DIR = '_cache'
 # Bump this with any changes to `fetch_all_records`
-CACHE_VERSION = 1
+CACHE_VERSION = 2
 
 def git_commits_for(path):
     return subprocess.check_output(['git', 'log', "--format=%H", path]).strip().decode().splitlines()
@@ -77,6 +77,7 @@ def fetch_all_records():
             record = InputRecord(
                 timestamp,
                 race['state_name'],
+                race['state_id'],
                 race['electoral_votes'],
                 race['candidates'].as_list(),
                 race['votes'],
@@ -106,6 +107,7 @@ InputRecord = collections.namedtuple(
     [
         'timestamp',
         'state_name',
+        'state_abbrev',
         'electoral_votes',
         'candidates',
         'votes',
@@ -402,11 +404,14 @@ def json_to_summary(
     return iteration_info, summary
 
 states_updated = []
+states_updated_abbrev = []
 
 for rows in records.values():
     latest_batch_time = datetime.datetime.strptime(rows[-1].timestamp, '%Y-%m-%dT%H:%M:%S.%fZ')
 
     state_name = rows[0].state_name
+    state_abbrev = rows[0].state_abbrev
+
     summarized[state_name] = []
     state_formatted_name[state_name] = f"{state_name} (EV: {rows[0].electoral_votes})"
 
@@ -445,6 +450,7 @@ for rows in records.values():
 
     if summarized[state_name] and summarized[state_name][0].timestamp == latest_batch_time:
         states_updated.append(state_name)
+        states_updated_abbrev.append(state_abbrev)
 
 # Pull out the battleground state summaries
 battlegrounds_summarized = {
@@ -509,7 +515,7 @@ def html_output(path, html_table, states_updated, other_page_html):
         page_metadata = json.dumps({
             "template_hash": TEMPLATE_HASH,
             "results_hash": RESULTS_HASH,
-            "states_updated": states_updated,
+            "states_updated": states_updated_abbrev,
         })
 
         html = html_template \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation

Fixes #378

###### Changes

This busts the cache because we weren't including `state_id` in `InputRecord` before.

I haven't actually tested the notifications, but the diff looked correct to me. The HTML file was the only generated file that changed, and the only change was `states_updated` in this line changing to abbreviations: https://github.com/alex/nyt-2020-election-scraper/blob/7ad43fb804c0977cc927bb172f4d95472a618fec/battleground-state-changes.html#L219

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [ ] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
