### PR TITLE
Fix notifying all states from battleground states page

### DIFF
--- a/print-battleground-state-changes
+++ b/print-battleground-state-changes
@@ -303,6 +303,7 @@ records = fetch_all_records()
 # Where we’ll aggregate the data from the JSON files
 summarized = {}
 state_formatted_name = {}
+state_abbrev = {}
 
 def json_to_summary(
     state_name: str,
@@ -404,16 +405,15 @@ def json_to_summary(
     return iteration_info, summary
 
 states_updated = []
-states_updated_abbrev = []
 
 for rows in records.values():
     latest_batch_time = datetime.datetime.strptime(rows[-1].timestamp, '%Y-%m-%dT%H:%M:%S.%fZ')
 
     state_name = rows[0].state_name
-    state_abbrev = rows[0].state_abbrev
 
     summarized[state_name] = []
     state_formatted_name[state_name] = f"{state_name} (EV: {rows[0].electoral_votes})"
+    state_abbrev[state_name] = rows[0].state_abbrev
 
     last_iteration_info = IterationInfo(
         vote_diff=None,
@@ -450,7 +450,6 @@ for rows in records.values():
 
     if summarized[state_name] and summarized[state_name][0].timestamp == latest_batch_time:
         states_updated.append(state_name)
-        states_updated_abbrev.append(state_abbrev)
 
 # Pull out the battleground state summaries
 battlegrounds_summarized = {
@@ -510,6 +509,8 @@ def html_output(path, html_table, states_updated, other_page_html):
     with open("battleground-state-changes.html.tmpl", "r", encoding='utf8') as f:
         html_template += f.read()
     TEMPLATE_HASH = hashlib.sha256(html_template.encode('utf8')).hexdigest()
+
+    states_updated_abbrev = [state_abbrev[state_name] for state_name in states_updated]
 
     with open(path,"w", encoding='utf8') as f:
         page_metadata = json.dumps({


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation

When I implemented #380, I misread the code and didn't realized that the `states_updated` in `html_output` was not the same as the global `states_updated` list, which lead to me introducing a bug where the battleground states page would show notifications intended for the all states page.

###### Changes

Add a `state_abbrev` dict, similar to `state_formatted_name`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
