### PR TITLE
Disable automatic runs of the scrape job

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   workflow_dispatch:
-  schedule:
-    - cron:  '0 */1 * * *'
 
 jobs:
   scheduled:


### PR DESCRIPTION
###### Motivation

No need to keep consuming Github's resources. (❤️ @ github)

###### Changes

Removes the cron schedule from the scrape workflow

- [x] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
